### PR TITLE
Feature/interaction_values

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -4,6 +4,7 @@ Smart explainer module
 import logging
 import copy
 import pandas as pd
+import numpy as np
 from shapash.webapp.smart_app import SmartApp
 from shapash.utils.io import save_pickle
 from shapash.utils.io import load_pickle
@@ -11,7 +12,7 @@ from shapash.utils.transform import inverse_transform, apply_postprocessing
 from shapash.utils.transform import adapt_contributions
 from shapash.utils.utils import get_host_name
 from shapash.utils.threading import CustomThread
-from shapash.utils.shap_backend import shap_contributions, check_explainer
+from shapash.utils.shap_backend import shap_contributions, check_explainer, get_shap_interaction_values
 from shapash.utils.check import check_model, check_label_dict, check_ypred, check_contribution_object,\
                                 check_postprocessing, check_features_name
 from shapash.manipulation.select_lines import keep_right_contributions
@@ -314,6 +315,24 @@ class SmartExplainer:
         """
         check_contribution_object(self._case, self._classes, contributions)
         return self.state.validate_contributions(contributions, self.x_init)
+
+    def get_interaction_values(self, n_samples_max=None):
+        """
+        Compute shap interaction values for each row of x_init.
+        This function is only available for explainer of type TreeExplainer (used for tree based models).
+        Please refer to the official tree shap paper for more information : https://arxiv.org/pdf/1802.03888.pdf
+
+        Parameters
+        ----------
+        n_samples_max : int, optional
+            Limit the number of points for which we compute the interactions.
+
+        Returns
+        -------
+        np.ndarray
+            Shap interaction values for each sample as an array of shape (# samples x # features x # features).
+        """
+        return get_shap_interaction_values(self.x_init[:n_samples_max], self.explainer)
 
     def apply_preprocessing(self, contributions, preprocessing=None):
         """

--- a/shapash/utils/shap_backend.py
+++ b/shapash/utils/shap_backend.py
@@ -12,6 +12,7 @@ You can also watch the tutorials which shows how to use shapash
 with contributions calculated by lime or eli5 library
 """
 import pandas as pd
+import numpy as np
 import shap
 from shapash.utils.model_synoptic import simple_tree_model, catboost_model, linear_model, svm_model
 
@@ -75,3 +76,27 @@ def check_explainer(explainer):
                 "explainer doesn't correspond to a shap explainer object"
             )
     return explainer
+
+
+def get_shap_interaction_values(x_df, explainer):
+    """
+    Compute the shap interaction values for a given dataframe.
+    Also checks if the explainer is a TreeExplainer.
+
+    Parameters
+    ----------
+    x_df : pd.DataFrame
+        DataFrame for which will be computed the interaction values using the explainer.
+    explainer : shap.TreeExplainer
+        explainer object used to compute the interaction values.
+
+    Returns
+    -------
+    np.ndarray
+        Shap interaction values for each sample as an array of shape (# samples x # features x # features).
+    """
+    if not isinstance(explainer, shap.TreeExplainer):
+        raise ValueError(f"Explainer type ({type(explainer)}) is not a TreeExplainer. "
+                         f"Shap interaction values can only be computed for TreeExplainer types")
+
+    return explainer.shap_interaction_values(x_df)

--- a/shapash/utils/shap_backend.py
+++ b/shapash/utils/shap_backend.py
@@ -92,11 +92,18 @@ def get_shap_interaction_values(x_df, explainer):
 
     Returns
     -------
-    np.ndarray
+    shap_interaction_values : np.ndarray
         Shap interaction values for each sample as an array of shape (# samples x # features x # features).
     """
     if not isinstance(explainer, shap.TreeExplainer):
         raise ValueError(f"Explainer type ({type(explainer)}) is not a TreeExplainer. "
                          f"Shap interaction values can only be computed for TreeExplainer types")
 
-    return explainer.shap_interaction_values(x_df)
+    shap_interaction_values = explainer.shap_interaction_values(x_df)
+
+    # For models with vector outputs the previous function returns one array for each output.
+    # We sum the contributions here.
+    if isinstance(shap_interaction_values, list):
+        shap_interaction_values = np.sum(shap_interaction_values, axis=0)
+
+    return shap_interaction_values

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -1218,3 +1218,21 @@ class TestSmartExplainer(unittest.TestCase):
                    for feature in xpl.x_pred.columns )
 
         assert predictor_2.mask_params == xpl.mask_params
+
+    def test_get_interaction_values_1(self):
+        df = pd.DataFrame({
+            "y": np.random.randint(2, size=50),
+            "a": np.random.rand(50),
+            "b": np.random.rand(50),
+        })
+
+        clf = cb.CatBoostClassifier(n_estimators=1).fit(df[['a', 'b']], df['y'])
+
+        xpl = SmartExplainer()
+        xpl.compile(x=df.drop('y', axis=1), model=clf)
+
+        shap_interaction_values = xpl.get_interaction_values(n_samples_max=10)
+        assert shap_interaction_values.shape[0] == 10
+
+        shap_interaction_values = xpl.get_interaction_values()
+        assert shap_interaction_values.shape[0] == df.shape[0]


### PR DESCRIPTION
# Description
This Pull request answer to the issue #120.
Adding a method to SmartExplainer to compute the shap interaction values between variables for TreeExplainer types.

- New method in SmartExplainer object used to compute interaction values
- Parameter to limit the number of samples on which we want to compute the interaction values
- Implementation of a function in shap_backend.py used to ckeck that the explainer is a TreeExplainer and that calls the shap.shap_interaction_values method.
- New unit tests added

## Type of change
- [ ] New feature

# How Has This Been Tested?
- pytest
- Test the function and method in a jupyter notebook

**Test Configuration**:
* OS: Mac OS
* Python version: 3.8.5
* Shapash version: 1.1.0

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules