### PR TITLE
fix save method in SmartExplainer

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -695,7 +695,7 @@ class SmartExplainer:
         """
         dict_to_save = {}
         for att in self.__dict__.keys():
-            if isinstance(getattr(self, att), (list, dict, pd.DataFrame, pd.Series, type(None))) or att == "model":
+            if isinstance(getattr(self, att), (list, dict, pd.DataFrame, pd.Series, type(None), bool)) or att == "model":
                 dict_to_save.update({att: getattr(self, att)})
         save_pickle(dict_to_save, path)
 

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -783,6 +783,22 @@ class TestSmartExplainer(unittest.TestCase):
         assert all(attrib in attrib_xpl2 for attrib in attrib_xpl)
         assert all(attrib2 in attrib_xpl for attrib2 in attrib_xpl2)
 
+    def test_save_load(self):
+        """
+        Test save + load methods
+        """
+        pkl_file, xpl = init_sme_to_pickle_test()
+        xpl.save(pkl_file)
+        xpl2 = SmartExplainer()
+        xpl2.load(pkl_file)
+
+        attrib_xpl = [element for element in xpl.__dict__.keys()]
+        attrib_xpl2 = [element for element in xpl2.__dict__.keys()]
+
+        assert all(attrib in attrib_xpl2 for attrib in attrib_xpl)
+        assert all(attrib2 in attrib_xpl for attrib2 in attrib_xpl2)
+        os.remove(pkl_file)
+
     def test_check_y_pred_1(self):
         """
         Unit test check y pred


### PR DESCRIPTION
# Description
Fixing issues #133 and #131 : when saving then loading SmartExplainer object, there was a problem when plotting with new loaded SmartExplainer.

## Type of change
The `save` method of the SmartExplainer object was not saving boolean attributes like postprocessing_modifications.
Now includes the boolean attributes to the saved pickle file.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Notebook
- [ ] pytest

**Test Configuration**:
* OS: Mac OS
* Python version: 3.8
* Shapash version: 1.1.0

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules