### PR TITLE
Feature/auto compute y_pred attribute when running app

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -734,7 +734,7 @@ class SmartExplainer:
 
     def predict(self):
         """
-        The predict_proba compute the proba values for each x_init row
+        The predict method computes the model output for each x_init row and stores it in y_pred attribute
         """
         self.y_pred = predict(self.model, self.x_init)
 

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -20,7 +20,7 @@ from .smart_state import SmartState
 from .multi_decorator import MultiDecorator
 from .smart_plotter import SmartPlotter
 from .smart_predictor import SmartPredictor
-from shapash.utils.model import predict_proba
+from shapash.utils.model import predict_proba, predict
 
 logging.basicConfig(level=logging.INFO)
 
@@ -144,7 +144,7 @@ class SmartExplainer:
             single or multiple contributions (multi-class) to handle.
             if pandas.Dataframe, the index and columns should be share with the prediction set.
             if np.ndarray, index and columns will be generated according to x dataset
-        y_pred : pandas.Series, optional (default: None)
+        y_pred : pandas.Series or pandas.DataFrame, optional (default: None)
             Prediction values (1 column only).
             The index must be identical to the index of x_pred.
             This is an interesting parameter for more explicit outputs. Shapash lets users define their own predict,
@@ -726,14 +726,17 @@ class SmartExplainer:
                 "pickle file must contain dictionary"
             )
 
-
     def predict_proba(self):
         """
         The predict_proba compute the proba values for each x_init row
         """
         self.proba_values = predict_proba(self.model, self.x_init, self._classes)
 
-
+    def predict(self):
+        """
+        The predict_proba compute the proba values for each x_init row
+        """
+        self.y_pred = predict(self.model, self.x_init)
 
     def to_pandas(
             self,
@@ -883,9 +886,7 @@ class SmartExplainer:
         >>> app.kill()
         """
         if self.y_pred is None:
-            raise ValueError(
-                "You have to specify y_pred argument. Please use add() or compile() method"
-            )
+            self.predict()
         if hasattr(self, '_case'):
             self.smartapp = SmartApp(self)
             if host is None:

--- a/shapash/utils/model.py
+++ b/shapash/utils/model.py
@@ -79,3 +79,27 @@ def extract_features_model(model, model_attribute):
                 return getattr(model,model_attribute[0])
             else:
                 return extract_features_model(getattr(model,model_attribute[0]), model_attribute[1:])
+
+
+def predict(model, x_init):
+    """
+    The predict function computes the prediction values for each x_init row
+
+    Parameters
+    -------
+    model: model object
+        model used to perform predictions
+    x_init: pandas.DataFrame
+        Observations on which to compute predictions.
+
+    Returns
+    -------
+    pandas.DataFrame
+            1-column dataframe containing the predictions.
+    """
+    if hasattr(model, 'predict'):
+        y_pred = pd.DataFrame(model.predict(x_init), columns=['pred'], index=x_init.index)
+    else:
+        raise ValueError("model has no predict method")
+
+    return y_pred

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -872,7 +872,7 @@ class TestSmartExplainer(unittest.TestCase):
         model = LinearRegression().fit(X, y_true)
 
         xpl.compile(x=X, model=model)
-        xpl.predict()  # y_false should be replaced by predictions which are equal to y_true
+        xpl.predict()
 
         pd.testing.assert_frame_equal(xpl.y_pred, y_true, check_dtype=False)
 


### PR DESCRIPTION
# Description
This PR allows to automatically compute y_pred attribute when launching dash app.
As stated in issue #135 y_pred is optional so it should not cause any error when running app.

Fixes #135

## Type of change

- [ ] New feature

# How Has This Been Tested?

- [ ] pytest
- [ ] notebook

**Test Configuration**:
* OS: Mac OS
* Python version: 3.8
* Shapash version: 1.1.0