### PR TITLE
Sort features to mask in filters form

### DIFF
--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -374,7 +374,7 @@ class SmartApp:
                 dbc.Label(
                     "Feature(s) to mask :"),
                 dcc.Dropdown(
-                    options=[{'label': key, 'value': value} for key, value in sorted(self.explainer.inv_features_dict, key=self.explainer.inv_features_dict.get).items()],
+                    options=[{'label': key, 'value': value} for key, value in sorted(self.explainer.inv_features_dict.items(), key=lambda item: item[0])],
                     value='', multi=True, searchable=True,
                     id="masked_contrib_id"
                 ),

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -374,7 +374,7 @@ class SmartApp:
                 dbc.Label(
                     "Feature(s) to mask :"),
                 dcc.Dropdown(
-                    options=[{'label': key, 'value': value} for key, value in self.explainer.inv_features_dict.items()],
+                    options=[{'label': key, 'value': value} for key, value in sorted(self.explainer.inv_features_dict, key=self.explainer.inv_features_dict.get).items()],
                     value='', multi=True, searchable=True,
                     id="masked_contrib_id"
                 ),


### PR DESCRIPTION
# Description

This PR change the default order of features to mask, it is now displayed in alphabetical order.

Fixes # WebApp - Sort Features in the "Feature(s) to mask :" list #117

## Type of change

Webapp enhancement.

# How Has This Been Tested?

Tested locally.
Python 3.8
MacOS


- launch webapp

**Test Configuration**:
* OS:
* Python version: 3.8
* Shapash version: 1.1.0

