### PR TITLE
Init feature to_smartexplainer

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -18,7 +18,7 @@ from shapash.manipulation.select_lines import keep_right_contributions
 from .smart_state import SmartState
 from .multi_decorator import MultiDecorator
 from .smart_plotter import SmartPlotter
-from .smart_predictor import SmartPredictor
+import shapash.explainer.smart_predictor
 from shapash.utils.model import predict_proba, predict
 
 logging.basicConfig(level=logging.INFO)
@@ -974,7 +974,7 @@ class SmartExplainer:
             }
         params_smartpredictor.append(self.mask_params)
 
-        return SmartPredictor(*params_smartpredictor)
+        return shapash.explainer.smart_predictor.SmartPredictor(*params_smartpredictor)
 
     def check_x_y_attributes(self, x_str, y_str):
         """

--- a/shapash/utils/load_smartpredictor.py
+++ b/shapash/utils/load_smartpredictor.py
@@ -1,7 +1,7 @@
 """
 load_smartpredictor module
 """
-from shapash.explainer.smart_explainer import SmartPredictor
+from shapash.explainer.smart_predictor import SmartPredictor
 from shapash.utils.io import load_pickle
 
 def load_smartpredictor(path):


### PR DESCRIPTION
# Description

Add a new method on SmartPredictor object "to_smartexplainer" to switch from a SmartPredictor Object to a SmartExpxlainer one.
- Start with a check to ensure that the add_input step has been done with the SmartPredictor to get the specific data on which we want to analyse several charts
- Check if preprocessing isn't a ColumnTransformer, otherwise raise ValueError
- Initialize SmartExplainer Object with attributes from SmartPredictor
- Compute the compile step of SmartExplainer with attributes and input used by the SmartPredictor for parameters

Fixes #111 

## Type of change

- [ ] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

- Unit test added on test_smart_predictor.py

**Test Configuration**:
* OS: Linux
* Python version: 3.6/3.7/3.8
* Shapash version: 1.2.0

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules