### PR TITLE
fix math domain error in digit counter by adding a conditional

### DIFF
--- a/shapash/utils/utils.py
+++ b/shapash/utils/utils.py
@@ -151,8 +151,12 @@ def compute_digit_number(value):
     int
         number of digits
     """
-    first_nz = int(math.log10(abs(value)))
-    digit = abs(min(3,first_nz) - 3)
+    # fix for 0 value
+    if(value == 0):
+        first_nz = 1
+    else:
+        first_nz = int(math.log10(abs(value)))
+    digit = abs(min(3, first_nz) - 3)
     return digit
 
 def add_text(text_list,sep):


### PR DESCRIPTION
# Description

Fixes `math domain error` in the digit counter when a value of zero is passed to the function. No additional dependencies are required for this change.

Fixes #156 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested the code for a data set where the error originally occurred and prevented rendering of the charts.

**Test Configuration**:
* OS: Windows
* Python version: 3.6.2
* Shapash version: 1.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules