### PR TITLE
Fix : generate report issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ to compute contributions.
 
 ## 🛠 Installation
 
-Shapash is intended to work with Python 3.6 or above. Installation can be done with pip:
+Shapash is intended to work with Python versions 3.6 to 3.8. Installation can be done with pip:
 
 ```
 pip install shapash

--- a/docs/tutorials/tuto-shapash-report01.rst
+++ b/docs/tutorials/tuto-shapash-report01.rst
@@ -194,6 +194,9 @@ parameters.
         ]
     )
 
+Note: Sometimes the jupyter kernel used when generating the report is not the right one.
+If this happen you should consider using the ``kernel_name`` parameter to indicate what kernel to use.
+
 Customize your own report
 -------------------------
 

--- a/docs/tutorials/tuto-shapash-report01.rst
+++ b/docs/tutorials/tuto-shapash-report01.rst
@@ -194,8 +194,8 @@ parameters.
         ]
     )
 
-Note: Sometimes the jupyter kernel used when generating the report is not the right one.
-If this happen you should consider using the ``kernel_name`` parameter to indicate what kernel to use.
+Note: You might want to specify the jupyter kernel used when generating the report.
+You should consider using the ``kernel_name`` parameter to indicate what kernel to use.
 
 Customize your own report
 -------------------------

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1027,7 +1027,8 @@ class SmartExplainer:
                         title_description=None,
                         metrics=None,
                         working_dir=None,
-                        notebook_path=None):
+                        notebook_path=None,
+                        kernel_name=None):
         """
         This method will generate an HTML report containing different information about the project.
 
@@ -1068,6 +1069,10 @@ class SmartExplainer:
         notebook_path : str, optional
             Path to the notebook used to generate the report. If None, the Shapash base report
             notebook will be used.
+        kernel_name : str, optional
+            Name of the kernel used to generate the report. This parameter can be usefull if
+            you have multiple jupyter kernels and that the method does not use the right kernel
+            by default.
 
         Examples
         --------
@@ -1112,7 +1117,8 @@ class SmartExplainer:
                 title_description=title_description,
                 metrics=metrics
             ),
-            notebook_path=notebook_path
+            notebook_path=notebook_path,
+            kernel_name=kernel_name
         )
         export_and_save_report(working_dir=working_dir, output_file=output_file)
 

--- a/shapash/report/generation.py
+++ b/shapash/report/generation.py
@@ -19,6 +19,7 @@ def execute_report(
         y_test: Optional[Union[pd.Series, pd.DataFrame]] = None,
         config: Optional[dict] = None,
         notebook_path: Optional[str] = None,
+        kernel_name: Optional[str] = None
 ):
     """
     Executes the base_report.ipynb notebook and saves the results in working_dir.
@@ -42,6 +43,10 @@ def execute_report(
     notebook_path : str, optional
         Path to the notebook used to generate the report. If None, the Shapash base report
         notebook will be used.
+    kernel_name : str, optional
+        Name of the kernel used to generate the report. This parameter can be usefull if
+        you have multiple jupyter kernels and that the method does not use the right kernel
+        by default.
     """
     if config is None:
         config = {}
@@ -63,7 +68,8 @@ def execute_report(
             dir_path=working_dir,
             project_info_file=project_info_file,
             config=config
-        )
+        ),
+        kernel_name=kernel_name
     )
 
 

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -18,7 +18,7 @@ from shapash.report.visualisation import print_md, print_html, print_css_style, 
 from shapash.report.data_analysis import perform_global_dataframe_analysis, perform_univariate_dataframe_analysis
 from shapash.report.plots import generate_fig_univariate, generate_confusion_matrix_plot, \
     generate_correlation_matrix_fig
-from shapash.report.common import series_dtype, get_callable, compute_col_types
+from shapash.report.common import series_dtype, get_callable, compute_col_types, VarType
 
 logging.basicConfig(level=logging.INFO)
 
@@ -277,9 +277,11 @@ class ProjectReport:
                         group_id='target'
                     )
         if multivariate_analysis:
-            print_md("### Mutlivariate analysis")
-            fig_corr = generate_correlation_matrix_fig(self.df_train_test, max_features=20)
-            print_html(convert_fig_to_html(fig=fig_corr))
+            # Need at least two numerical features
+            if len([v for v in compute_col_types(self.df_train_test).values() if v == VarType.TYPE_NUM]) > 1:
+                print_md("### Mutlivariate analysis")
+                fig_corr = generate_correlation_matrix_fig(self.df_train_test, max_features=20)
+                print_html(convert_fig_to_html(fig=fig_corr))
         print_md('---')
 
     def _display_dataset_analysis_global(self):

--- a/tutorial/report/tuto-shapash-report01.ipynb
+++ b/tutorial/report/tuto-shapash-report01.ipynb
@@ -282,8 +282,8 @@
    "id": "central-karma",
    "metadata": {},
    "source": [
-    "> Note: Sometimes the jupyter kernel used when generating the report is not the right one. \n",
-    "If this happen you should consider using the `kernel_name` parameter to indicate what kernel to use. "
+    "> Note: You might want to specify the jupyter kernel used when generating the report.\n",
+    "You should consider using the `kernel_name` parameter to indicate what kernel to use."
    ]
   },
   {

--- a/tutorial/report/tuto-shapash-report01.ipynb
+++ b/tutorial/report/tuto-shapash-report01.ipynb
@@ -279,6 +279,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "central-karma",
+   "metadata": {},
+   "source": [
+    "> Note: Sometimes the jupyter kernel used when generating the report is not the right one. \n",
+    "If this happen you should consider using the `kernel_name` parameter to indicate what kernel to use. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "elementary-sympathy",
    "metadata": {},
    "source": [


### PR DESCRIPTION
This PR fixes two issues that can occur when generating the Shapash Report : 
- The correlation matrix cannot be computed when the data only contains categorical features. One unit test was added to check that the problem is fixed.
- The kernel used by papermill when generating the report is sometimes not the default one. To fix this I added the  `kernel_name` parameter in the `generate_report`method that is then passed to papermill.