### PR TITLE
Feature: better display high numbers with comma separator between thousands

### DIFF
--- a/shapash/report/common.py
+++ b/shapash/report/common.py
@@ -1,5 +1,6 @@
 from typing import Union, Optional
 from enum import Enum
+from numbers import Number
 
 import pandas as pd
 import os
@@ -172,3 +173,51 @@ def compute_top_correlations_features(corr: pd.DataFrame, max_features: int) -> 
                 set_features.add(sorted_corr.index[i][1])
         i += 1
     return list(set_features)
+
+
+def display_value(value: float, thousands_separator: str = ',', decimal_separator: str = '.') -> str:
+    """
+    Display a value as a string with specific format.
+
+    Parameters
+    ----------
+    value : float
+        Value to display.
+    thousands_separator : str
+        The separator used to separate thousands.
+    decimal_separator : str
+        The separator used to separate decimal values.
+
+    Returns
+    -------
+    str
+
+    Examples
+    --------
+    >>> display_value(1255000, thousands_separator=',')
+    '1,255,000'
+
+    """
+    value_str = '{:,}'.format(value).replace(',', '/thousands/').replace('.', '/decimal/')
+    return value_str.replace('/thousands/', thousands_separator).replace('/decimal/', decimal_separator)
+
+
+def replace_dict_values(obj: dict, replace_fn: callable, *args) -> dict:
+    """
+    Recursively iterates over all values of obj and changes its values using the replace_fn
+
+    Parameters
+    ----------
+    obj : dict
+    replace_fn : callable
+
+    Returns
+    -------
+    dict
+    """
+    for k, v in obj.items():
+        if isinstance(v, dict):
+            obj[k] = replace_dict_values(v, replace_fn)
+        elif isinstance(v, Number):
+            obj[k] = replace_fn(v, *args)
+    return obj

--- a/shapash/report/data_analysis.py
+++ b/shapash/report/data_analysis.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pandas as pd
 
-from shapash.report.common import VarType, series_dtype, numeric_is_continuous
+from shapash.report.common import VarType, display_value, replace_dict_values
 from shapash.webapp.utils.utils import round_to_k
 
 
@@ -36,6 +36,8 @@ def perform_global_dataframe_analysis(df: Optional[pd.DataFrame]) -> dict:
             global_d[stat] = int(global_d[stat])  # Keeping the exact number
         elif isinstance(global_d[stat], float):
             global_d[stat] = round_to_k(global_d[stat], 3)
+
+    replace_dict_values(global_d, display_value, ',', '.')
 
     return global_d
 
@@ -73,6 +75,8 @@ def perform_univariate_dataframe_analysis(df: Optional[pd.DataFrame], col_types:
                 d[col][stat] = int(d[col][stat])  # Keeping the exact number here
             elif isinstance(d[col][stat], float):
                 d[col][stat] = round_to_k(d[col][stat], 3)  # Rounding to 3 important figures
+
+    replace_dict_values(d, display_value, ',', '.')
 
     return d
 

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -18,7 +18,8 @@ from shapash.report.visualisation import print_md, print_html, print_css_style, 
 from shapash.report.data_analysis import perform_global_dataframe_analysis, perform_univariate_dataframe_analysis
 from shapash.report.plots import generate_fig_univariate, generate_confusion_matrix_plot, \
     generate_correlation_matrix_fig
-from shapash.report.common import series_dtype, get_callable, compute_col_types, VarType
+from shapash.report.common import series_dtype, get_callable, compute_col_types, VarType, display_value
+from shapash.webapp.utils.utils import round_to_k
 
 logging.basicConfig(level=logging.INFO)
 
@@ -436,7 +437,8 @@ class ProjectReport:
                     logging.info(f"Could not compute following metric : {metric['path']}. \n{e}")
                     continue
                 if isinstance(res, Number):
-                    print_md(f"**{metric['name']} :** {round(res, 2)}")
+                    res = display_value(round_to_k(res, 3))
+                    print_md(f"**{metric['name']} :** {res}")
                 elif isinstance(res, (list, tuple, np.ndarray)):
                     print_md(f"**{metric['name']} :**")
                     print_html(pd.DataFrame(res).to_html(classes="greyGridTable"))

--- a/tests/unit_tests/report/test_common.py
+++ b/tests/unit_tests/report/test_common.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 from shapash.report.common import VarType, series_dtype, numeric_is_continuous, get_callable, \
-    compute_top_correlations_features
+    compute_top_correlations_features, display_value, replace_dict_values
 
 
 class TestCommon(unittest.TestCase):
@@ -119,3 +119,25 @@ class TestCommon(unittest.TestCase):
         list_features = compute_top_correlations_features(corr=corr, max_features=5)
 
         assert len(list_features) == 5
+
+    def test_display_value_1(self):
+        value = 123456.789
+        expected_str = '123,456.789'
+        assert display_value(value, ',', '.') == expected_str
+
+    def test_display_value_2(self):
+        value = 123456.789
+        expected_str = '123 456,789'
+        assert display_value(value, ' ', ',') == expected_str
+
+    def test_display_value_3(self):
+        value = 123456.789
+        expected_str = '123.456,789'
+        assert display_value(value, '.', ',') == expected_str
+
+    def test_replace_dict_values_1(self):
+        d = {'a': 1234, 'b': 0.1234, 'c': {'d': 123.456, 'e': 1234, 'f': {'g': 1234}}}
+        expected_d = {'a': '1,234', 'b': '0.1234', 'c': {'d': '123.456', 'e': '1,234', 'f': {'g': '1,234'}}}
+        res_d = replace_dict_values(d, display_value, ',', '.')
+        assert d == expected_d
+        assert res_d == expected_d  # The replace_dict_values function modify inplace but also returns the result dict

--- a/tests/unit_tests/report/test_data_analysis.py
+++ b/tests/unit_tests/report/test_data_analysis.py
@@ -18,10 +18,10 @@ class TestDataAnalysis(unittest.TestCase):
 
         d = perform_global_dataframe_analysis(df)
         expected_d = {
-            'number of features': 3,
-            'number of observations': 6,
-            'missing values': 2,
-            '% missing values': 0.111,
+            'number of features': '3',
+            'number of observations': '6',
+            'missing values': '2',
+            '% missing values': '0.111',
         }
         TestCase().assertDictEqual(d, expected_d)
 
@@ -42,40 +42,40 @@ class TestDataAnalysis(unittest.TestCase):
         d = perform_univariate_dataframe_analysis(df, col_types=compute_col_types(df))
         expected_d = {
             'int_continuous_data': {
-                'count': 60,
-                'mean': 29.5,
-                'std': 17.5,
-                'min': 0,
-                '25%': 14.8,
-                '50%': 29.5,
-                '75%': 44.2,
-                'max': 59
+                'count': '60',
+                'mean': '29.5',
+                'std': '17.5',
+                'min': '0',
+                '25%': '14.8',
+                '50%': '29.5',
+                '75%': '44.2',
+                'max': '59'
             },
             'float_continuous_data': {
-                'count': 60,
-                'mean': 1,
-                'std': 0.592,
-                'min': 0,
-                '25%': 0.5,
-                '50%': 1,
-                '75%': 1.5,
-                'max': 2
+                'count': '60',
+                'mean': '1',
+                'std': '0.592',
+                'min': '0',
+                '25%': '0.5',
+                '50%': '1',
+                '75%': '1.5',
+                'max': '2'
             },
             'int_cat_data': {
-                'distinct values': 2,
-                'missing values': 0
+                'distinct values': '2',
+                'missing values': '0'
             },
             'float_cat_data': {
-                'distinct values': 2,
-                'missing values': 0
+                'distinct values': '2',
+                'missing values': '0'
             },
             'string_data': {
-                'distinct values': 5,
-                'missing values': 10
+                'distinct values': '5',
+                'missing values': '10'
             },
             'bool_data': {
-                'distinct values': 2,
-                'missing values': 10
+                'distinct values': '2',
+                'missing values': '10'
             }
         }
         TestCase().assertDictEqual(d, expected_d)


### PR DESCRIPTION
# Description

This PR allows do display more properly big numbers with comas as a separator beween thousands.
We still need to find a way to easily configure the separators when generating the report in case we want a space instead of a coma. I think this should be handle in another PR in which we will handle other configuration options like the option to not display some parts of the report.

## Type of change

Please delete options that are not relevant.

- [X] New feature 

# How Has This Been Tested?

- New unit tests have been added
- pytest

**Test Configuration**:
* OS: MacOS
* Python version: 3.7
* Shapash version: 1.1.3
