### PR TITLE
Fix local_pred changing x_init dtype

### DIFF
--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -839,7 +839,7 @@ class SmartPlotter:
             else:
                 value = None
         elif self.explainer._case == "regression":
-            value = self.explainer.model.predict(self.explainer.x_init.loc[index].to_frame().T)[0]
+            value = self.explainer.model.predict(self.explainer.x_init.loc[[index]])[0]
 
         return value
 


### PR DESCRIPTION
pandas.DataFrame.T will change the input datatypes. If bool and float are mixed, the resulting dtype is 'object' which xgboost does not support.

fixes #178 