### PR TITLE
Feature: handle groups of features in contribution plot

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -544,7 +544,6 @@ class SmartExplainer:
                 self.inv_features_dict[group_name] = group_name
                 self.features_desc[group_name] = 1000
 
-
     def check_contributions(self):
         """
         Check if contributions and prediction set match in terms of shape and index.

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -542,6 +542,7 @@ class SmartExplainer:
             if group_name not in self.features_dict.keys():
                 self.features_dict[group_name] = group_name
                 self.inv_features_dict[group_name] = group_name
+                self.features_desc[group_name] = 1000
 
 
     def check_contributions(self):

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -328,20 +328,20 @@ class SmartPlotter:
         if metadata:
             metadata = {k: [round_to_k(x, 3) if isinstance(x, Number) else x for x in v]
                         for k, v in metadata.items()}
-            customdata = np.array([col_values for col_values in metadata.values()])
-            customdata = np.swapaxes(customdata, 0, 1)
-            customdata_keys = list(metadata.keys())
+            text_groups_features = np.swap = np.array([col_values for col_values in metadata.values()])
+            text_groups_features = np.swapaxes(text_groups_features, 0, 1)
+            text_groups_features_keys = list(metadata.keys())
             hovertemplate = '<b>%{hovertext}</b><br />' + \
                             'Contribution: %{y:.4f} <br />' + \
                             '<br />'.join([
-                                '{}: %{{customdata[{}]}}'.format(customdata_keys[i], i)
-                                for i in range(len(customdata_keys))
+                                '{}: %{{text[{}]}}'.format(text_groups_features_keys[i], i)
+                                for i in range(len(text_groups_features_keys))
                             ]) + '<extra></extra>'
         else:
             hovertemplate = '<b>%{hovertext}</b><br />' +\
                             f'{feature_name} : ' +\
                             '%{x}<br />Contribution: %{y:.4f}<extra></extra>'
-            customdata = None
+            text_groups_features = None
 
         fig.add_scatter(
             x=feature_values.values.flatten(),
@@ -349,7 +349,8 @@ class SmartPlotter:
             mode='markers',
             hovertext=hv_text,
             hovertemplate=hovertemplate,
-            customdata=customdata
+            customdata=feature_values.index.values,
+            text=text_groups_features
         )
 
         self._update_contributions_fig(fig=fig,

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -6,6 +6,7 @@ import random
 import copy
 import numpy as np
 import pandas as pd
+from sklearn.manifold import TSNE
 from plotly import graph_objs as go
 import plotly.express as px
 from plotly.offline import plot
@@ -272,6 +273,7 @@ class SmartPlotter:
                      proba_values=None,
                      col_modality=None,
                      col_scale=None,
+                     metadata=None,
                      addnote=None,
                      subtitle=None,
                      width=900,
@@ -322,15 +324,30 @@ class SmartPlotter:
         else:
             hv_text = [f"Id: {x}<br />" for x in feature_values.index]
 
+        if metadata:
+            customdata = np.array([col_values for col_values in metadata.values()])
+            customdata = np.swapaxes(customdata, 0, 1)
+            customdata_keys = list(metadata.keys())
+            hovertemplate = '<b>%{hovertext}</b><br />' + \
+                            'Contribution: %{y:.4f} <br />' + \
+                            '<br />'.join([
+                                '{}:%{{customdata[{}]:.3f}}'.format(customdata_keys[i], i)
+                                for i in range(len(customdata_keys))
+                            ]) + \
+                            '<extra></extra>'
+        else:
+            hovertemplate = '<b>%{hovertext}</b><br />' +\
+                            f'{feature_name} : ' +\
+                            '%{x}<br />Contribution: %{y:.4f}<extra></extra>'
+            customdata = None
+
         fig.add_scatter(
             x=feature_values.values.flatten(),
             y=contributions.values.flatten(),
             mode='markers',
             hovertext=hv_text,
-            hovertemplate='<b>%{hovertext}</b><br />' +
-                          f'{feature_name} : ' +
-                          '%{x}<br />Contribution: %{y:.4f}<extra></extra>',
-            customdata=contributions.index.values
+            hovertemplate=hovertemplate,
+            customdata=customdata
         )
 
         self._update_contributions_fig(fig=fig,
@@ -1060,15 +1077,24 @@ class SmartPlotter:
         if not isinstance(col, (str, int)):
             raise ValueError('parameter col must be string or int.')
 
-        col_id = self.explainer.check_features_name([col])[0]
-        col_name = self.explainer.columns_dict[col_id]
+        col_is_group = self.explainer.features_groups and col in self.explainer.features_groups.keys()
 
-        col_value_count = self.explainer.features_desc[col_name]
-
-        if self.explainer.features_dict:
-            col_label = self.explainer.features_dict[col_name]
+        # Case where col is a group of features
+        if col_is_group:
+            contributions = self.explainer.contributions_groups
+            col_label = self.explainer.features_dict[col]
+            col_name = self.explainer.features_groups[col]  # Here col_name is actually a list of features
+            col_value_count = self.explainer.features_desc[col]
         else:
-            col_label = col_name
+            contributions = self.explainer.contributions
+            col_id = self.explainer.check_features_name([col])[0]
+            col_name = self.explainer.columns_dict[col_id]
+            col_value_count = self.explainer.features_desc[col_name]
+
+            if self.explainer.features_dict:
+                col_label = self.explainer.features_dict[col_name]
+            else:
+                col_label = col_name
 
         # Sampling
         if selection is None:
@@ -1100,7 +1126,7 @@ class SmartPlotter:
 
         # Classification Case
         if self.explainer._case == "classification":
-            subcontrib = self.explainer.contributions[label_num]
+            subcontrib = contributions[label_num]
             if self.explainer.y_pred is not None:
                 col_value = self.explainer._classes[label_num]
             subtitle = f"Response: <b>{label_value}</b>"
@@ -1119,7 +1145,7 @@ class SmartPlotter:
 
         # Regression Case - color scale
         elif self.explainer._case == "regression":
-            subcontrib = self.explainer.contributions
+            subcontrib = contributions
             if self.explainer.y_pred is not None:
                 if not hasattr(self, "pred_colorscale"):
                     self.pred_colorscale = self.tuning_colorscale(self.explainer.y_pred)
@@ -1127,10 +1153,25 @@ class SmartPlotter:
 
         # Subset
         if self.explainer.postprocessing_modifications:
-            feature_values = self.explainer.x_contrib_plot.loc[list_ind, col_name].to_frame()
+            feature_values = self.explainer.x_contrib_plot.loc[list_ind, col_name]
         else:
-            feature_values = self.explainer.x_pred.loc[list_ind, col_name].to_frame()
-        contrib = subcontrib.loc[list_ind, col_name].to_frame()
+            feature_values = self.explainer.x_pred.loc[list_ind, col_name]
+
+        if col_is_group:
+            # Project in 1D the feature values
+            feature_values_proj_1d = TSNE(n_components=1, random_state=1).fit_transform(feature_values)
+            feature_values = pd.Series(feature_values_proj_1d[:, 0], name=col, index=feature_values.index)
+            contrib = subcontrib.loc[list_ind, col].to_frame()
+            top_features_of_group = self.explainer.features_imp.loc[self.explainer.features_groups[col]]\
+                                        .sort_values(ascending=False)[:4].index  # Displaying only top 4 features
+            metadata = {
+                self.explainer.features_dict[f_name]: self.explainer.x_pred[f_name]
+                for f_name in top_features_of_group
+            }
+        else:
+            contrib = subcontrib.loc[list_ind, col_name].to_frame()
+            metadata = None
+        feature_values = feature_values.to_frame()
 
         if self.explainer.y_pred is not None:
             y_pred = self.explainer.y_pred.loc[list_ind]
@@ -1149,7 +1190,7 @@ class SmartPlotter:
         # selecting the best plot : Scatter, Violin?
         if col_value_count > violin_maxf:
             fig = self.plot_scatter(feature_values, contrib, col_label, y_pred, proba_values, col_value, col_scale,
-                                    addnote,
+                                    metadata, addnote,
                                     subtitle, width, height, file_name, auto_open)
         else:
             fig = self.plot_violin(feature_values, contrib, col_label, y_pred, proba_values, col_value, col_scale,

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -323,7 +323,7 @@ class SmartPlotter:
         if pred is not None:
             hv_text = [f"Id: {x}<br />Predict: {y}" for x, y in zip(feature_values.index, pred.values.flatten())]
         else:
-            hv_text = [f"Id: {x}<br />" for x in feature_values.index]
+            hv_text = [f"Id: {x}" for x in feature_values.index]
 
         if metadata:
             metadata = {k: [round_to_k(x, 3) if isinstance(x, Number) else x for x in v]

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -7,15 +7,13 @@ import random
 import copy
 import numpy as np
 import pandas as pd
-from sklearn.manifold import TSNE
 from plotly import graph_objs as go
 import plotly.express as px
 from plotly.offline import plot
 from shapash.manipulation.select_lines import select_lines
-from shapash.manipulation.summarize import compute_features_import
+from shapash.manipulation.summarize import compute_features_import, project_feature_values_1d
 from shapash.utils.utils import add_line_break, truncate_str, compute_digit_number, add_text, \
     maximum_difference_sort_value, compute_sorted_variables_interactions_list_indices
-from shapash.utils.transform import get_features_transform_mapping
 from shapash.webapp.utils.utils import round_to_k
 
 
@@ -1162,16 +1160,8 @@ class SmartPlotter:
             feature_values = self.explainer.x_pred.loc[list_ind, col_name]
 
         if col_is_group:
-            # Getting mapping of variables to transform categorical features with corresponding encoded variables
-            encoding_mapping = get_features_transform_mapping(self.explainer.preprocessing, self.explainer.x_init)
-            if encoding_mapping is not None:
-                col_names_in_xinit = list()
-                for c in feature_values.columns:
-                    col_names_in_xinit.extend(encoding_mapping.get(c, [c]))
-                feature_values = self.explainer.x_init.loc[feature_values.index, col_names_in_xinit]
-            # Project in 1D the feature values
-            feature_values_proj_1d = TSNE(n_components=1, random_state=1).fit_transform(feature_values)
-            feature_values = pd.Series(feature_values_proj_1d[:, 0], name=col, index=feature_values.index)
+            feature_values = project_feature_values_1d(feature_values, col, self.explainer.preprocessing,
+                                                       self.explainer.x_init)
             contrib = subcontrib.loc[list_ind, col].to_frame()
             if self.explainer.features_imp is None:
                 self.explainer.compute_features_import()

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -323,7 +323,7 @@ class SmartPlotter:
         if pred is not None:
             hv_text = [f"Id: {x}<br />Predict: {y}" for x, y in zip(feature_values.index, pred.values.flatten())]
         else:
-            hv_text = [f"Id: {x}" for x in feature_values.index]
+            hv_text = [f"Id: {x}<br />" for x in feature_values.index]
 
         if metadata:
             metadata = {k: [round_to_k(x, 3) if isinstance(x, Number) else x for x in v]

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -1114,8 +1114,7 @@ class SmartPlotter:
                 list_ind = random.sample(selection, max_points)
                 addnote = "Length of random Subset : "
         else:
-            ValueError('parameter selection must be a list')
-
+            raise ValueError('parameter selection must be a list')
         if addnote is not None:
             addnote = add_text([addnote,
                                 f"{len(list_ind)} ({int(np.round(100 * len(list_ind) / self.explainer.x_pred.shape[0]))}%)"],
@@ -1173,6 +1172,11 @@ class SmartPlotter:
                 self.explainer.features_dict[f_name]: self.explainer.x_pred[f_name]
                 for f_name in top_features_of_group
             }
+            text_group = "Feature values were projected on the x axis using t-SNE"
+            if addnote is not None:
+                addnote = add_text([addnote, text_group], sep=' - ')
+            else:
+                addnote = text_group
         else:
             contrib = subcontrib.loc[list_ind, col_name].to_frame()
             metadata = None

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -1172,7 +1172,7 @@ class SmartPlotter:
                 self.explainer.features_dict[f_name]: self.explainer.x_pred[f_name]
                 for f_name in top_features_of_group
             }
-            text_group = "Feature values were projected on the x axis using t-SNE"
+            text_group = "Features values were projected on the x axis using t-SNE"
             if addnote is not None:
                 addnote = add_text([addnote, text_group], sep=' - ')
             else:

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -1160,8 +1160,8 @@ class SmartPlotter:
             feature_values = self.explainer.x_pred.loc[list_ind, col_name]
 
         if col_is_group:
-            feature_values = project_feature_values_1d(feature_values, col, self.explainer.preprocessing,
-                                                       self.explainer.x_init)
+            feature_values = project_feature_values_1d(feature_values, col, self.explainer.x_pred,
+                                                       self.explainer.x_init, self.explainer.preprocessing)
             contrib = subcontrib.loc[list_ind, col].to_frame()
             if self.explainer.features_imp is None:
                 self.explainer.compute_features_import()

--- a/shapash/manipulation/summarize.py
+++ b/shapash/manipulation/summarize.py
@@ -129,7 +129,7 @@ def group_contributions(contributions, features_groups):
     return new_contributions
 
 
-def project_feature_values_1d(feature_values, col, preprocessing, x_init):
+def project_feature_values_1d(feature_values, col, x_pred, x_init, preprocessing):
     """
     Project feature values of a group of features in 1 dimension.
     If feature_values contains categorical features, use preprocessing to get
@@ -143,8 +143,12 @@ def project_feature_values_1d(feature_values, col, preprocessing, x_init):
         Name of the group of features.
     preprocessing : category_encoders, ColumnTransformer, list, dict, optional
         Preprocessing used to encode categorical variables.
+    x_pred : pd.DataFrame
+        Pandas dataframe before preprocessing transformations
     x_init : pd.DataFrame
-        Values of variables after encoding.
+        Pandas dataframe after preprocessing transformations
+    preprocessing : category_encoders or ColumnTransformer or list or dict or list of dict
+        The processing apply to the original data
 
     Returns
     -------
@@ -152,7 +156,7 @@ def project_feature_values_1d(feature_values, col, preprocessing, x_init):
         Series containing the projected feature values.
     """
     # Getting mapping of variables to transform categorical features with corresponding encoded variables
-    encoding_mapping = get_features_transform_mapping(preprocessing, x_init)
+    encoding_mapping = get_features_transform_mapping(x_pred, x_init, preprocessing)
     if encoding_mapping is not None:
         col_names_in_xinit = list()
         for c in feature_values.columns:

--- a/shapash/manipulation/summarize.py
+++ b/shapash/manipulation/summarize.py
@@ -4,6 +4,8 @@ Summarize Module
 import numpy as np
 import pandas as pd
 from pandas.core.common import flatten
+from sklearn.manifold import TSNE
+from shapash.utils.transform import get_features_transform_mapping
 
 
 def summarize_el(dataframe, mask, prefix):
@@ -125,3 +127,38 @@ def group_contributions(contributions, features_groups):
         new_contributions = new_contributions.drop(features_grouped, axis=1)
 
     return new_contributions
+
+
+def project_feature_values_1d(feature_values, col, preprocessing, x_init):
+    """
+    Project feature values of a group of features in 1 dimension.
+    If feature_values contains categorical features, use preprocessing to get
+    the corresponding encoded variables.
+
+    Parameters
+    ----------
+    feature_values : pd.DataFrame
+        DataFrame that contains the feature values
+    col : str
+        Name of the group of features.
+    preprocessing : category_encoders, ColumnTransformer, list, dict, optional
+        Preprocessing used to encode categorical variables.
+    x_init : pd.DataFrame
+        Values of variables after encoding.
+
+    Returns
+    -------
+    feature_values : pd.Series
+        Series containing the projected feature values.
+    """
+    # Getting mapping of variables to transform categorical features with corresponding encoded variables
+    encoding_mapping = get_features_transform_mapping(preprocessing, x_init)
+    if encoding_mapping is not None:
+        col_names_in_xinit = list()
+        for c in feature_values.columns:
+            col_names_in_xinit.extend(encoding_mapping.get(c, [c]))
+        feature_values = x_init.loc[feature_values.index, col_names_in_xinit]
+    # Project in 1D the feature values
+    feature_values_proj_1d = TSNE(n_components=1, random_state=1).fit_transform(feature_values)
+    feature_values = pd.Series(feature_values_proj_1d[:, 0], name=col, index=feature_values.index)
+    return feature_values

--- a/shapash/manipulation/summarize.py
+++ b/shapash/manipulation/summarize.py
@@ -157,11 +157,10 @@ def project_feature_values_1d(feature_values, col, x_pred, x_init, preprocessing
     """
     # Getting mapping of variables to transform categorical features with corresponding encoded variables
     encoding_mapping = get_features_transform_mapping(x_pred, x_init, preprocessing)
-    if encoding_mapping is not None:
-        col_names_in_xinit = list()
-        for c in feature_values.columns:
-            col_names_in_xinit.extend(encoding_mapping.get(c, [c]))
-        feature_values = x_init.loc[feature_values.index, col_names_in_xinit]
+    col_names_in_xinit = list()
+    for c in feature_values.columns:
+        col_names_in_xinit.extend(encoding_mapping.get(c, [c]))
+    feature_values = x_init.loc[feature_values.index, col_names_in_xinit]
     # Project in 1D the feature values
     feature_values_proj_1d = TSNE(n_components=1, random_state=1).fit_transform(feature_values)
     feature_values = pd.Series(feature_values_proj_1d[:, 0], name=col, index=feature_values.index)

--- a/shapash/utils/category_encoder_backend.py
+++ b/shapash/utils/category_encoder_backend.py
@@ -267,13 +267,14 @@ def transform_ordinal(x_in, encoding):
     return x_in
 
 
-def get_col_mapping_ce(list_encoding):
+def get_col_mapping_ce(encoder):
     """
     Get the columns mapping of a category encoder list.
+
     Parameters
     ----------
-    list_encoding : list
-        A list containing all encoders.
+    encoder : category_encoders
+        The encoder used.
 
     Returns
     -------
@@ -281,17 +282,16 @@ def get_col_mapping_ce(list_encoding):
         Dict of mapping between dataframe columns before and after encoding.
     """
     dict_col_mapping = dict()
-    for enc in list_encoding:
-        enc = enc.mapping
-        if isinstance(enc, dict):
-            for col in enc.keys():
-                dict_col_mapping[col] = [col]
-        elif isinstance(enc, list):
-            for col_enc in enc:
-                if isinstance(col_enc.get('mapping'), pd.DataFrame):
-                    dict_col_mapping[col_enc.get('col')] = col_enc.get('mapping').columns.to_list()
-                else:
-                    dict_col_mapping[col_enc.get('col')] = [col_enc.get('col')]
-        else:
-            raise NotImplementedError
+    encoder_mapping = encoder.mapping
+    if isinstance(encoder_mapping, dict):
+        for col in encoder_mapping.keys():
+            dict_col_mapping[col] = [col]
+    elif isinstance(encoder_mapping, list):
+        for col_enc in encoder_mapping:
+            if isinstance(col_enc.get('mapping'), pd.DataFrame):
+                dict_col_mapping[col_enc.get('col')] = col_enc.get('mapping').columns.to_list()
+            else:
+                dict_col_mapping[col_enc.get('col')] = [col_enc.get('col')]
+    else:
+        raise NotImplementedError
     return dict_col_mapping

--- a/shapash/utils/category_encoder_backend.py
+++ b/shapash/utils/category_encoder_backend.py
@@ -281,8 +281,15 @@ def get_col_mapping_ce(encoder):
     dict_col_mapping : dict
         Dict of mapping between dataframe columns before and after encoding.
     """
+    if str(type(encoder)) in [category_encoder_ordinal, category_encoder_onehot, category_encoder_basen,
+                              category_encoder_targetencoder]:
+        encoder_mapping = encoder.mapping
+    elif str(type(encoder)) == category_encoder_binary:
+        encoder_mapping = encoder.base_n_encoder.mapping
+    else:
+        raise NotImplementedError(f"{encoder} not supported.")
+
     dict_col_mapping = dict()
-    encoder_mapping = encoder.mapping
     if isinstance(encoder_mapping, dict):
         for col in encoder_mapping.keys():
             dict_col_mapping[col] = [col]

--- a/shapash/utils/category_encoder_backend.py
+++ b/shapash/utils/category_encoder_backend.py
@@ -265,3 +265,33 @@ def transform_ordinal(x_in, encoding):
         transform = pd.Series(data=column_mapping.values, index=column_mapping.index)
         x_in[col_name] = x_in[col_name].map(transform).astype(switch.get('mapping').values.dtype)
     return x_in
+
+
+def get_col_mapping_ce(list_encoding):
+    """
+    Get the columns mapping of a category encoder list.
+    Parameters
+    ----------
+    list_encoding : list
+        A list containing all encoders.
+
+    Returns
+    -------
+    dict_col_mapping : dict
+        Dict of mapping between dataframe columns before and after encoding.
+    """
+    dict_col_mapping = dict()
+    for enc in list_encoding:
+        enc = enc.mapping
+        if isinstance(enc, dict):
+            for col in enc.keys():
+                dict_col_mapping[col] = [col]
+        elif isinstance(enc, list):
+            for col_enc in enc:
+                if isinstance(col_enc.get('mapping'), pd.DataFrame):
+                    dict_col_mapping[col_enc.get('col')] = col_enc.get('mapping').columns.to_list()
+                else:
+                    dict_col_mapping[col_enc.get('col')] = [col_enc.get('col')]
+        else:
+            raise NotImplementedError
+    return dict_col_mapping

--- a/shapash/utils/columntransformer_backend.py
+++ b/shapash/utils/columntransformer_backend.py
@@ -438,11 +438,11 @@ def get_col_mapping_ct(encoder, x_init):
                     idx_init += 1
 
             elif str(type(estimator)) in supported_category_encoder:
-                dict_mapping_ce = get_col_mapping_ce([estimator])
-                for k in dict_mapping_ce.keys():
-                    dict_col_mapping[k] = list()
-                    for _ in dict_mapping_ce[k]:
-                        dict_col_mapping[k].append(x_init.columns.to_list()[idx_init])
+                dict_mapping_ce = get_col_mapping_ce(estimator)
+                for f_name in dict_mapping_ce.keys():
+                    dict_col_mapping[name + '_' + f_name] = list()
+                    for _ in dict_mapping_ce[f_name]:
+                        dict_col_mapping[name + '_' + f_name].append(x_init.columns.to_list()[idx_init])
                         idx_init += 1
 
             else:
@@ -451,7 +451,7 @@ def get_col_mapping_ct(encoder, x_init):
         elif estimator == 'passthrough':
             features_out = encoder._feature_names_in[features]
             for f_name in features_out:
-                dict_col_mapping[f_name] = [f_name]
+                dict_col_mapping[f_name] = [x_init.columns.to_list()[idx_init]]
                 idx_init += 1
 
     return dict_col_mapping

--- a/shapash/utils/transform.py
+++ b/shapash/utils/transform.py
@@ -1,13 +1,19 @@
 """
 Transform Module
 """
-from shapash.utils.category_encoder_backend import inv_transform_ce
-from shapash.utils.columntransformer_backend import inv_transform_ct
-from shapash.utils.category_encoder_backend import supported_category_encoder
-from shapash.utils.columntransformer_backend import columntransformer
-from shapash.utils.columntransformer_backend import supported_sklearn
-from shapash.utils.columntransformer_backend import transform_ct
-from shapash.utils.category_encoder_backend import transform_ce
+from shapash.utils.columntransformer_backend import (
+    columntransformer,
+    inv_transform_ct,
+    supported_sklearn,
+    transform_ct,
+    get_col_mapping_ct
+)
+from shapash.utils.category_encoder_backend import (
+    transform_ce,
+    inv_transform_ce,
+    supported_category_encoder,
+    get_col_mapping_ce
+)
 import re
 import numpy as np
 import pandas as pd
@@ -283,3 +289,38 @@ def adapt_contributions(case,contributions):
     else:
         return contributions
 
+
+def get_features_transform_mapping(preprocessing=None, x_init=None):
+    """
+    Get the columns mapping from preprocessing.
+
+    Parameters
+    ----------
+    preprocessing : category_encoders or ColumnTransformer or list or dict or list of dict
+        The processing apply to the original data
+    x_init : pd.DataFrame
+        Pandas dataframe after encoder transformations
+
+    Returns
+    -------
+    dict
+        the mapping between columns names before and after preprocessing.
+    """
+    if preprocessing is None:
+        return None
+
+    # Transform preprocessing into a list
+    list_encoding = preprocessing_tolist(preprocessing)
+
+    # Check encoding are supported
+    use_ct, use_ce = check_transformers(list_encoding)
+
+    if use_ct:
+        return get_col_mapping_ct(list_encoding, x_init)
+    elif use_ce:
+        return get_col_mapping_ce(list_encoding)
+    else:
+        if isinstance(list_encoding[0], list):
+            return {enc['col']: [enc['col']] for enc_list in list_encoding for enc in enc_list}
+        elif isinstance(list_encoding[0], dict):
+            return {enc['col']: [enc['col']] for enc in list_encoding}

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -960,17 +960,155 @@ class TestSmartPlotter(unittest.TestCase):
         classification with proba
         """
         col = 'X1'
-        xpl =self.smart_explainer
+        xpl = self.smart_explainer
         xpl.proba_values = pd.DataFrame(
-            data = np.array(
+            data=np.array(
                 [[0.4, 0.6],
                 [0.3, 0.7]]),
-            columns = ['class_1','class_2'],
-            index = xpl.x_init.index.values)
+            columns=['class_1', 'class_2'],
+            index=xpl.x_init.index.values)
         output = self.smart_explainer.plot.contribution_plot(col)
         assert str(type(output.data[-1])) == "<class 'plotly.graph_objs._scatter.Scatter'>"
         self.assertListEqual(list(output.data[-1]['marker']['color']), [0.6, 0.7])
         self.assertListEqual(list(output.data[-1]['y']), [-0.3, 4.7])
+
+    def test_contribution_plot_12(self):
+        """
+        contribution plot with groups of features for classification case
+        """
+        x_init = pd.DataFrame(
+            data=np.array(
+                [[0, 34],
+                 [1, 27]]),
+            columns=['X1', 'X2'],
+            index=['person_A', 'person_B']
+        )
+        xpl = self.smart_explainer
+        xpl.inv_features_dict = {}
+        col = 'group1'
+        xpl.x_init = x_init
+        xpl.contributions[0] = pd.concat([xpl.contributions[0]] * 10, ignore_index=True)
+        xpl.contributions[1] = pd.concat([xpl.contributions[1]] * 10, ignore_index=True)
+        xpl.x_pred = pd.concat([xpl.x_pred] * 10, ignore_index=True)
+        xpl.x_init = pd.concat([xpl.x_init] * 10, ignore_index=True)
+        xpl.postprocessing_modifications = False
+        xpl.preprocessing = None
+        # Creates a group of features named group1
+        xpl.features_groups = {'group1': ['X1', 'X2']}
+        xpl.contributions_groups = xpl.state.compute_grouped_contributions(xpl.contributions, xpl.features_groups)
+        xpl.features_imp_groups = None
+        xpl._update_features_dict_with_groups(features_groups=xpl.features_groups)
+
+        output = xpl.plot.contribution_plot(col, proba=False)
+
+        assert len(output.data) == 1
+        assert output.data[0].type == 'scatter'
+        self.setUp()
+
+    def test_contribution_plot_13(self):
+        """
+        contribution plot with groups of features for regression case
+        """
+        x_init = pd.DataFrame(
+            data=np.array(
+                [[0, 34],
+                 [1, 27]]),
+            columns=['X1', 'X2'],
+            index=['person_A', 'person_B']
+        )
+        xpl = self.smart_explainer
+        xpl.inv_features_dict = {}
+        col = 'group1'
+        xpl.x_init = x_init
+        xpl.contributions = pd.concat([self.contrib1] * 10, ignore_index=True)
+        xpl._case = "regression"
+        xpl.state = xpl.choose_state(xpl.contributions)
+        xpl.x_pred = pd.concat([xpl.x_pred] * 10, ignore_index=True)
+        xpl.x_init = pd.concat([xpl.x_init] * 10, ignore_index=True)
+        xpl.postprocessing_modifications = False
+        xpl.preprocessing = None
+        # Creates a group of features named group1
+        xpl.features_groups = {'group1': ['X1', 'X2']}
+        xpl.contributions_groups = xpl.state.compute_grouped_contributions(xpl.contributions, xpl.features_groups)
+        xpl.features_imp_groups = None
+        xpl._update_features_dict_with_groups(features_groups=xpl.features_groups)
+
+        output = xpl.plot.contribution_plot(col, proba=False)
+
+        assert len(output.data) == 1
+        assert output.data[0].type == 'scatter'
+        self.setUp()
+
+    def test_contribution_plot_14(self):
+        """
+        contribution plot with groups of features for classification case and subset
+        """
+        x_init = pd.DataFrame(
+            data=np.array(
+                [[0, 34],
+                 [1, 27]]),
+            columns=['X1', 'X2'],
+            index=['person_A', 'person_B']
+        )
+        xpl = self.smart_explainer
+        xpl.inv_features_dict = {}
+        col = 'group1'
+        xpl.x_init = x_init
+        xpl.contributions[0] = pd.concat([xpl.contributions[0]] * 10, ignore_index=True)
+        xpl.contributions[1] = pd.concat([xpl.contributions[1]] * 10, ignore_index=True)
+        xpl.x_pred = pd.concat([xpl.x_pred] * 10, ignore_index=True)
+        xpl.x_init = pd.concat([xpl.x_init] * 10, ignore_index=True)
+        xpl.postprocessing_modifications = False
+        xpl.preprocessing = None
+        # Creates a group of features named group1
+        xpl.features_groups = {'group1': ['X1', 'X2']}
+        xpl.contributions_groups = xpl.state.compute_grouped_contributions(xpl.contributions, xpl.features_groups)
+        xpl.features_imp_groups = None
+        xpl._update_features_dict_with_groups(features_groups=xpl.features_groups)
+
+        subset = list(range(10))
+        output = xpl.plot.contribution_plot(col, proba=False, selection=subset)
+
+        assert len(output.data) == 1
+        assert output.data[0].type == 'scatter'
+        assert len(output.data[0].x) == 10
+        self.setUp()
+
+    def test_contribution_plot_15(self):
+        """
+        contribution plot with groups of features for regression case with subset
+        """
+        x_init = pd.DataFrame(
+            data=np.array(
+                [[0, 34],
+                 [1, 27]]),
+            columns=['X1', 'X2'],
+            index=['person_A', 'person_B']
+        )
+        xpl = self.smart_explainer
+        xpl.inv_features_dict = {}
+        col = 'group1'
+        xpl.x_init = x_init
+        xpl.contributions = pd.concat([self.contrib1] * 10, ignore_index=True)
+        xpl._case = "regression"
+        xpl.state = xpl.choose_state(xpl.contributions)
+        xpl.x_pred = pd.concat([xpl.x_pred] * 10, ignore_index=True)
+        xpl.x_init = pd.concat([xpl.x_init] * 10, ignore_index=True)
+        xpl.postprocessing_modifications = False
+        xpl.preprocessing = None
+        # Creates a group of features named group1
+        xpl.features_groups = {'group1': ['X1', 'X2']}
+        xpl.contributions_groups = xpl.state.compute_grouped_contributions(xpl.contributions, xpl.features_groups)
+        xpl.features_imp_groups = None
+        xpl._update_features_dict_with_groups(features_groups=xpl.features_groups)
+
+        subset = list(range(10))
+        output = xpl.plot.contribution_plot(col, proba=False, selection=subset)
+
+        assert len(output.data) == 1
+        assert output.data[0].type == 'scatter'
+        assert len(output.data[0].x) == 10
+        self.setUp()
 
     def test_plot_features_import_1(self):
         """

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -734,7 +734,7 @@ class TestSmartPlotter(unittest.TestCase):
         expected_output = go.Scatter(x=xpl.x_pred[col],
                                      y=xpl.contributions[col],
                                      mode='markers',
-                                     hovertext=[f"Id: {x}<br />" for x in xpl.x_pred.index])
+                                     hovertext=[f"Id: {x}" for x in xpl.x_pred.index])
 
         assert np.array_equal(output.data[0].x, expected_output.x)
         assert np.array_equal(output.data[0].y, expected_output.y)

--- a/tests/unit_tests/utils/test_transform.py
+++ b/tests/unit_tests/utils/test_transform.py
@@ -1,0 +1,213 @@
+"""
+Unit test of transform module.
+"""
+import unittest
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+import sklearn.preprocessing as skp
+import category_encoders as ce
+from shapash.utils.transform import _get_preprocessing_mapping, get_features_transform_mapping
+
+
+class TestInverseTransformCaterogyEncoder(unittest.TestCase):
+    def test_get_preprocessing_mapping_1(self):
+        """
+        test _get_preprocessing_mapping with multiple encoding and dictionary
+        """
+        enc = ColumnTransformer(
+            transformers=[
+                ('onehot_ce', ce.OneHotEncoder(), ['city', 'state']),
+                ('onehot_skp', skp.OneHotEncoder(), ['city', 'state'])
+            ],
+            remainder='drop')
+
+        test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'C']},
+                            index=['index1', 'index2', 'index3'])
+
+        test_encoded = pd.DataFrame(enc.fit_transform(test))
+
+        input_dict1 = dict()
+        input_dict1['col'] = 'onehot_ce_city'
+        input_dict1['mapping'] = pd.Series(data=['chicago', 'paris'], index=['CH', 'PR'])
+        input_dict1['data_type'] = 'object'
+
+        input_dict2 = dict()
+        input_dict2['col'] = 'other'
+        input_dict2['mapping'] = pd.Series(data=['A', 'B', 'C'], index=['A-B', 'A-B', 'C'])
+        input_dict2['data_type'] = 'object'
+
+        input_dict3 = dict()
+        input_dict3['col'] = 'onehot_ce_state'
+        input_dict3['mapping'] = pd.Series(data=['US', 'FR'], index=['US-FR', 'US-FR'])
+        input_dict3['data_type'] = 'object'
+        list_dict = [input_dict2, input_dict3]
+
+        test_encoded.columns = ['col1_0', 'col1_1', 'col2_0', 'col2_1', 'col3_0', 'col3_1', 'col4_0', 'col4_1']
+
+        mapping = _get_preprocessing_mapping(test_encoded, [enc, input_dict1, list_dict])
+
+        expected_mapping = {'onehot_ce_city': ['col1_0', 'col1_1'], 'onehot_ce_state': ['col2_0', 'col2_1'],
+                            'onehot_skp_city': ['col3_0', 'col3_1'], 'onehot_skp_state': ['col4_0', 'col4_1']}
+        self.assertDictEqual(mapping, expected_mapping)
+
+    def test_get_preprocessing_mapping_2(self):
+        """
+        test _get_preprocessing_mapping with multiple encoding and drop option
+        """
+        enc = ColumnTransformer(
+            transformers=[
+                ('onehot_ce', ce.OneHotEncoder(), ['city', 'state']),
+                ('ordinal_skp', skp.OrdinalEncoder(), ['city'])
+            ],
+            remainder='drop')
+        test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'C']},
+                            index=['index1', 'index2', 'index3'])
+
+        test_encoded = pd.DataFrame(enc.fit_transform(test))
+        test_encoded.columns = ['col1_0', 'col1_1', 'col2_0', 'col2_1', 'col3']
+
+        mapping = _get_preprocessing_mapping(test_encoded, enc)
+
+        expected_mapping = {'onehot_ce_city': ['col1_0', 'col1_1'], 'onehot_ce_state': ['col2_0', 'col2_1'],
+                            'ordinal_skp_city': ['col3']}
+        self.assertDictEqual(mapping, expected_mapping)
+
+    def test_get_features_transform_mapping_1(self):
+        """
+        test get_features_transform_mapping with multiple encoding and dictionary
+        """
+        enc = ColumnTransformer(
+            transformers=[
+                ('onehot_ce', ce.OneHotEncoder(), ['city', 'state']),
+                ('onehot_skp', skp.OneHotEncoder(), ['city', 'state'])
+            ],
+            remainder='drop')
+
+        test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'C'],
+                             'other2': ['D', 'E', 'F']},
+                            index=['index1', 'index2', 'index3'])
+
+        test_encoded = pd.DataFrame(enc.fit_transform(test))
+
+        input_dict1 = dict()
+        input_dict1['col'] = 'onehot_ce_city'
+        input_dict1['mapping'] = pd.Series(data=['chicago', 'paris'], index=['CH', 'PR'])
+        input_dict1['data_type'] = 'object'
+
+        input_dict2 = dict()
+        input_dict2['col'] = 'other'
+        input_dict2['mapping'] = pd.Series(data=['A', 'B', 'C'], index=['A-B', 'A-B', 'C'])
+        input_dict2['data_type'] = 'object'
+
+        input_dict3 = dict()
+        input_dict3['col'] = 'onehot_ce_state'
+        input_dict3['mapping'] = pd.Series(data=['US', 'FR'], index=['US-FR', 'US-FR'])
+        input_dict3['data_type'] = 'object'
+        list_dict = [input_dict2, input_dict3]
+
+        test_encoded.columns = ['col1_0', 'col1_1', 'col2_0', 'col2_1', 'col3_0', 'col3_1', 'col4_0', 'col4_1']
+        # Construct expected x_init that will be built from test dataframe
+        x_init = pd.DataFrame({'onehot_ce_city': ['chicago', 'chicago', 'paris'],
+                               'onehot_ce_state': ['US', 'FR', 'FR'],
+                               'onehot_skp_city': ['chicago', 'chicago', 'paris'],
+                               'onehot_skp_state': ['US', 'FR', 'FR'],
+                               'other': ['A', 'B', 'C'],
+                               'other2': ['D', 'E', 'F']},
+                              index=['index1', 'index2', 'index3'])
+
+        mapping = get_features_transform_mapping(x_init, test_encoded, [enc, input_dict1, list_dict])
+
+        expected_mapping = {'onehot_ce_city': ['col1_0', 'col1_1'], 'onehot_ce_state': ['col2_0', 'col2_1'],
+                            'onehot_skp_city': ['col3_0', 'col3_1'], 'onehot_skp_state': ['col4_0', 'col4_1'],
+                            'other': ['other'], 'other2': ['other2']}
+        self.assertDictEqual(mapping, expected_mapping)
+
+    def test_get_features_transform_mapping_2(self):
+        """
+        test get_features_transform_mapping with multiple different encoding
+        """
+        enc = ColumnTransformer(
+            transformers=[
+                ('onehot_ce', ce.OneHotEncoder(), ['city']),
+                ('ordinal_skp', skp.OrdinalEncoder(), ['state'])
+            ],
+            remainder='drop')
+
+        test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'C'],
+                             'other2': ['D', 'E', 'F']},
+                            index=['index1', 'index2', 'index3'])
+
+        test_encoded = pd.DataFrame(enc.fit_transform(test))
+
+        test_encoded.columns = ['col1_0', 'col1_1', 'col2']
+        # Construct expected x_init that will be built from test dataframe
+        x_init = pd.DataFrame({'onehot_ce_city': ['chicago', 'chicago', 'paris'],
+                               'ordinal_skp_state': ['US', 'FR', 'FR'],
+                               'other': ['A', 'B', 'C'],
+                               'other2': ['D', 'E', 'F']},
+                              index=['index1', 'index2', 'index3'])
+
+        mapping = get_features_transform_mapping(x_init, test_encoded, enc)
+        print(mapping)
+
+        expected_mapping = {'onehot_ce_city': ['col1_0', 'col1_1'],
+                            'ordinal_skp_state': ['col2'],
+                            'other': ['other'], 'other2': ['other2']}
+        self.assertDictEqual(mapping, expected_mapping)
+
+    def test_get_features_transform_mapping_3(self):
+        """
+        test get_features_transform_mapping with category encoders
+        """
+        test = pd.DataFrame({'city': ['chicago', 'paris', 'chicago'],
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'B']})
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+
+        enc = ce.OneHotEncoder(cols=['city', 'state'], use_cat_names=True)
+        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+
+        x_init = pd.DataFrame({'city': ['chicago', 'paris', 'chicago'],
+                               'state': ['US', 'FR', 'FR'],
+                               'other': ['A', 'B', 'B']})
+
+        mapping = get_features_transform_mapping(x_init, test_encoded, enc)
+        expected_mapping = {'city': ['city_chicago', 'city_paris'],
+                            'state': ['state_US', 'state_FR'],
+                            'other': ['other']}
+
+        self.assertDictEqual(mapping, expected_mapping)
+
+    def test_get_features_transform_mapping_4(self):
+        """
+        test get_features_transform_mapping with list of category encoders
+        """
+        test = pd.DataFrame({'city': ['chicago', 'paris', 'chicago'],
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'B']})
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+
+        enc = ce.OneHotEncoder(cols=['state'], use_cat_names=True)
+        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+
+        enc2 = ce.OrdinalEncoder(cols=['city'])
+        test_encoded = enc2.fit_transform(test_encoded, y)
+
+        x_init = pd.DataFrame({'city': ['chicago', 'paris', 'chicago'],
+                               'state': ['US', 'FR', 'FR'],
+                               'other': ['A', 'B', 'B']})
+
+        mapping = get_features_transform_mapping(x_init, test_encoded, [enc, enc2])
+        expected_mapping = {'city': ['city'],
+                            'state': ['state_US', 'state_FR'],
+                            'other': ['other']}
+
+        self.assertDictEqual(mapping, expected_mapping)


### PR DESCRIPTION
# Description
This PR adds the option to pass a group of features in the contribution plot (`SmartPlotter.contribution_plot` method).
In order to have a group of features on this plot we had to project the feature values of the group on the x axis using a t-SNE.

Fixes #176

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)

- [x] New tests have been added

**Test Configuration**:
* OS: MacOs
* Python version: 3.7
* Shapash version: 1.3.2

Preview of the feature : 

Note that I used the compile method with following features groups : 
```
features_groups = {
    'group_house_size': ['LotArea', 'MasVnrArea', 'BsmtFinSF1', 'BsmtFinSF2', 'TotalBsmtSF', '1stFlrSF',
                        '2ndFlrSF', 'GrLivArea', 'GarageArea', 'WoodDeckSF', 'OpenPorchSF', 'EnclosedPorch',
                        '3SsnPorch', 'ScreenPorch', 'PoolArea'],
    'group_location': ['Street', 'Neighborhood'],
    'group_aspect': ['LandContour', 'LotShape', 'BsmtCond', 'PavedDrive', 'GarageQual', 'ExterQual']
}
```

![image](https://user-images.githubusercontent.com/48520594/117119272-1ab78f80-ad92-11eb-8ece-d332ca0ffcc8.png)


![image](https://user-images.githubusercontent.com/48520594/117119085-dcba6b80-ad91-11eb-9b06-e7034ae0dcc7.png)




