### PR TITLE
Prevent in the case of a regression to call the predict function if t…

### DIFF
--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -839,7 +839,10 @@ class SmartPlotter:
             else:
                 value = None
         elif self.explainer._case == "regression":
-            value = self.explainer.model.predict(self.explainer.x_init.loc[[index]])[0]
+            if self.explainer.y_pred is not None:
+                value = self.explainer.y_pred.loc[index]
+            else:
+                value = self.explainer.model.predict(self.explainer.x_init.loc[[index]])[0]
 
         return value
 


### PR DESCRIPTION
# Description

The web-app is making an unnecessary call to get a local prediction in the case of a regression even if predictions are already given.

Fixes #127 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

``` python
import numpy as np
import pandas as pd

import xgboost

import shap
from shapash.explainer.smart_explainer import SmartExplainer

X,y = shap.datasets.nhanesi()
X_display,y_display = shap.datasets.nhanesi(display=True) # human readable feature values
y = np.array(y)
X = X.drop('Unnamed: 0', axis=1)

xgb_train = xgboost.DMatrix(X, label=y)

params_train = {
    "eta": 0.002,
    "max_depth": 3,
    "objective": "survival:cox",
    "subsample": 0.5,
}

model = xgboost.train(params_train, xgb_train, num_boost_round=5)

# Smart explainer creation
xpl = SmartExplainer()
xpl.compile(
    x=X,
    model=model,
    y_pred=pd.Series(model.predict(xgb_train), name='probability'),
    contributions=model.predict(xgb_train, pred_contribs=True)[:, :-1]
)

app = xpl.run_app(title_story='test xgboost', port=8078)
```

**Test Configuration**:
* OS: linux
* Python version: 3.8
* Shapash version: 1.3.2

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules