### PR TITLE
Fix filters on float columns in webapp table

### DIFF
--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -148,7 +148,7 @@ class SmartApp:
                 std = self.dataframe[col].std()
                 if std != 0:
                     digit = max(round(log10(1 / std) + 1) + 2, 0)
-                    self.round_dataframe[col] = self.dataframe[col].map(f'{{:.{digit}f}}'.format)
+                    self.round_dataframe[col] = self.dataframe[col].map(f'{{:.{digit}f}}'.format).astype(float)
 
     def init_components(self):
         """


### PR DESCRIPTION
# Description
This PR fixes a bug in the WebApp. 
Float columns were converted to string when rounding to sufficient number of digits.
As a result we could not use filters on these columns.

Fixes #204 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Pytest
- Examples webapp launch