### PR TITLE
Feature/issue#231

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -954,13 +954,13 @@ class SmartExplainer:
         if self.features_imp is None or force:
             self.features_imp = self.state.compute_features_import(self.contributions)
 
-    def init_app(self, settings: dict = {}):
+    def init_app(self, settings: dict = None):
         """
         Simple init of SmartApp in case of host smartapp by another way
         
         Parameters
         ----------
-        settings : Dict
+        settings : dict (default: None)
             A dict describing the default webapp settings values to be used
             Possible settings (dict keys) are 'rows', 'points', 'violin', 'features'
             Values should be positive ints
@@ -987,7 +987,7 @@ class SmartExplainer:
         title_story: str (default: None)
             The default title is empty. You can specify a custom title
             for your webapp (can be reused in other methods like in a report, ...)
-        settings : dict (default: {})
+        settings : dict (default: None)
             A dict describing the default webapp settings values to be used
             Possible settings (dict keys) are 'rows', 'points', 'violin', 'features'
             Values should be positive ints

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1008,8 +1008,6 @@ class SmartExplainer:
         if self.y_pred is None:
             self.predict()
         if hasattr(self, '_case'):
-            if settings is None:
-                a=1
             self.smartapp = SmartApp(self, settings)
             if host is None:
                 host = "0.0.0.0"

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -954,13 +954,20 @@ class SmartExplainer:
         if self.features_imp is None or force:
             self.features_imp = self.state.compute_features_import(self.contributions)
 
-    def init_app(self):
+    def init_app(self, settings: dict = {}):
         """
         Simple init of SmartApp in case of host smartapp by another way
+        
+        Parameters
+        ----------
+        settings : Dict
+            A dict describing the default webapp settings values to be used
+            Possible settings (dict keys) are 'rows', 'points', 'violin', 'features'
+            Values should be positive ints
         """
-        self.smartapp = SmartApp(self)
+        self.smartapp = SmartApp(self, settings)
 
-    def run_app(self, port: int = None, host: str = None, title_story: str = None) -> CustomThread:
+    def run_app(self, port: int = None, host: str = None, title_story: str = None, settings: dict = None) -> CustomThread:
         """
         run_app method launches the interpretability web app associated with the shapash object.
         run_app method can be used directly in a Jupyter notebook
@@ -980,6 +987,10 @@ class SmartExplainer:
         title_story: str (default: None)
             The default title is empty. You can specify a custom title
             for your webapp (can be reused in other methods like in a report, ...)
+        settings : dict (default: {})
+            A dict describing the default webapp settings values to be used
+            Possible settings (dict keys) are 'rows', 'points', 'violin', 'features'
+            Values should be positive ints
 
         Returns
         -------
@@ -997,7 +1008,9 @@ class SmartExplainer:
         if self.y_pred is None:
             self.predict()
         if hasattr(self, '_case'):
-            self.smartapp = SmartApp(self)
+            if settings is None:
+                a=1
+            self.smartapp = SmartApp(self, settings)
             if host is None:
                 host = "0.0.0.0"
             if port is None:

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -43,13 +43,17 @@ class SmartApp:
             SmartExplainer instance to point to.
     """
 
-    def __init__(self, explainer):
+    def __init__(self, explainer, settings: dict = None):
         """
         Init on class instantiation, everything to be able to run the app on server.
         Parameters
         ----------
         explainer : SmartExplainer
             SmartExplainer object
+        settings : dict
+            A dict describing the default webapp settings values to be used
+            Possible settings (dict keys) are 'rows', 'points', 'violin', 'features'
+            Values should be positive ints
         """
         # APP
         self.server = Flask(__name__)
@@ -72,7 +76,12 @@ class SmartApp:
             'violin': 10,
             'features': 20,
         }
+        if settings is not None:
+            for k, v in self.settings_ini.items():
+                self.settings_ini[k] = settings[k] if k in settings and isinstance(settings[k], int) and 0 < settings[k] else v
+                
         self.settings = self.settings_ini.copy()
+
         self.predict_col = ['_predict_']
         self.explainer.features_imp = self.explainer.state.compute_features_import(self.explainer.contributions)
         if self.explainer._case == 'classification':

--- a/tests/unit_tests/webapp/test_webapp_settings.py
+++ b/tests/unit_tests/webapp/test_webapp_settings.py
@@ -1,0 +1,53 @@
+import unittest
+from shapash.explainer.smart_explainer import SmartExplainer
+from pathlib import Path
+from os import path
+import sys
+
+
+class TestWebappSettings(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        current = Path(path.abspath(__file__)).parent.parent.parent
+        self.xpl = SmartExplainer()
+        if str(sys.version)[0:3] == '3.6':
+            pkl_file = path.join(current, 'data/xpl_to_load_36.pkl')
+        elif str(sys.version)[0:3] == '3.7':
+            pkl_file = path.join(current, 'data/xpl_to_load_37.pkl')
+        elif str(sys.version)[0:3] == '3.8':
+            pkl_file = path.join(current, 'data/xpl_to_load_38.pkl')
+        elif str(sys.version)[0:3] == '3.9':
+            pkl_file = path.join(current, 'data/xpl_to_load_39.pkl')
+        else:
+            raise NotImplementedError
+        self.xpl.load(pkl_file)
+        super(TestWebappSettings, self).__init__(*args, **kwargs)
+
+    def test_settings_types(self):
+        settings = {'rows': None,
+                    'points': 5200.4,
+                    'violin': -1,
+                    'features': "oui"}
+        self.xpl.init_app(settings)
+        print(self.xpl.smartapp.settings)
+        assert all(isinstance(attrib, int) for k, attrib in self.xpl.smartapp.settings.items())
+
+    def test_settings_values(self):
+        settings = {'rows': 0,
+                    'points': 5200.4,
+                    'violin': -1,
+                    'features': "oui"}
+        self.xpl.init_app(settings)
+        assert all(attrib > 0 for k, attrib in self.xpl.smartapp.settings.items())
+
+    def test_settings_keys1(self):
+        settings = {}
+        self.xpl.init_app(settings)
+        assert all(k in ['rows', 'points', 'violin', 'features'] for k in self.xpl.smartapp.settings)
+
+    def test_settings_keys2(self):
+        settings = {'oui': 1,
+                    1: 2,
+                    "a": []}
+        self.xpl.init_app(settings)
+        assert all(k in ['rows', 'points', 'violin', 'features'] for k in self.xpl.smartapp.settings)


### PR DESCRIPTION
# Description

Fixes issue #231

## Type of change

- [X] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

All existing tests still pass.
New tests have been added in tests/unit_tests/webapp/ to test user input safeguards.
Run tests using pytests.

The new functionality was tested with the following settings :
`
xpl.load(some_pickle)
settings = {'rows': 15000,
            'points': 5200,
            'violin': -1,
            2: "foo"}
xpl.run_app(settings=settings, port=port)
print(xpl.smartapp.settings)
`
> {'rows': 15000, 'points': 5200, 'violin': 10, 'features': 20}

As intended, the valid numerical values are set as indicated in the settings dict, and used in the webapp. 
The other settings are discarded and replaced by the default (untouched) values. 
I intentionally did not cap those numerical values as I did not want to hinder any possible valid use case.

**Test Configuration**:
* OS: Linux
* Python version: 3.6
* Shapash version: 1.4.4

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas (N/A)
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules