### PR TITLE
fix remove files when generate report fail

### DIFF
--- a/shapash/__init__.py
+++ b/shapash/__init__.py
@@ -1,6 +1,6 @@
   
 """Top-level package."""
 
-__author__ = """Yann Golhen, Yann Lagré, Sebastien Bidault, Maxime Gendre, Thomas Bouche, Johann Martin"""
-__email__ = 'yann.golhen@maif.fr, yann.lagre@maif.fr, sebabstien.bidault@maif.fr, maxime.gendre@maif.fr'
+__author__ = """Yann Golhen, Yann Lagré, Sebastien Bidault, Maxime Gendre, Thomas Bouche, Johann Martin, Guillaume Vignal"""
+__email__ = 'yann.golhen@maif.fr, yann.lagre@maif.fr, sebabstien.bidault.marketing@maif.fr, thomas.bouche@maif.fr, guillaume.vignal@maif.fr'
 __version__ = '1.5.0'

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1239,23 +1239,29 @@ class SmartExplainer:
             raise AssertionError("Explainer object was not compiled. Please compile the explainer "
                                  "object using .compile(...) method before generating the report.")
 
-        execute_report(
-            working_dir=working_dir,
-            explainer=self,
-            project_info_file=project_info_file,
-            x_train=x_train,
-            y_train=y_train,
-            y_test=y_test,
-            config=dict(
-                title_story=title_story,
-                title_description=title_description,
-                metrics=metrics
-            ),
-            notebook_path=notebook_path,
-            kernel_name=kernel_name
-        )
-        export_and_save_report(working_dir=working_dir, output_file=output_file)
+        try:
+            execute_report(
+                working_dir=working_dir,
+                explainer=self,
+                project_info_file=project_info_file,
+                x_train=x_train,
+                y_train=y_train,
+                y_test=y_test,
+                config=dict(
+                    title_story=title_story,
+                    title_description=title_description,
+                    metrics=metrics
+                ),
+                notebook_path=notebook_path,
+                kernel_name=kernel_name
+            )
+            export_and_save_report(working_dir=working_dir, output_file=output_file)
 
-        if rm_working_dir:
-            shutil.rmtree(working_dir)
+            if rm_working_dir:
+                shutil.rmtree(working_dir)
+        
+        except Exception as e:
+            if rm_working_dir:
+                shutil.rmtree(working_dir)
+            raise e
 


### PR DESCRIPTION
# Description

When generate report, with method xpl.generate_report() and method fail, temporary files are not removed. it can saturate the temporary memory.

Set up Try except

Fixes #249 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* OS:Linux
* Python version:3.8
* Shapash version:1.5.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
