### PR TITLE
fix catboost version in dev requirements

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 pip==20.2.4
 dash==1.17.0
-catboost>=0.22
+catboost==0.26.1
 category-encoders==2.1.0
 dash-bootstrap-components==0.9.1
 dash-core-components==1.13.0


### PR DESCRIPTION
This PR sets the version of catboost in dev requirements as a new version of catboost generates errors when running tests on macOs.

This issue can be found on the catboost repo : https://github.com/catboost/catboost/issues/1877