### PR TITLE
fix lime compute with regression

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -242,7 +242,7 @@ class SmartExplainer:
                     contributions = lime_contributions(model=model,
                                                    x_init=self.x_init,
                                                    mode=self._case,
-                                                   num_classes=len(self._classes), **kwargs)
+                                                   classes=self._classes, **kwargs)
 
             else:
                 raise ValueError(

--- a/shapash/utils/lime_backend.py
+++ b/shapash/utils/lime_backend.py
@@ -12,7 +12,7 @@ def lime_contributions(model,
                        x_init,
                        x_train=None,
                        mode="classification",
-                       num_classes=None):
+                       classes=None):
     """
         Compute local contribution with the Lime library
         Parameters
@@ -30,8 +30,8 @@ def lime_contributions(model,
         x_train : pd.DataFrame
             Training dataset used as background.
         mode : "classification" or "regression"
-        num_classes: int (default :None)
-            Number of classes if len(classes)>2
+        classes: list, None
+            List of labels if the model used is for classification problem, None otherwise.
         Returns
         -------
         np.array or list of np.array
@@ -59,30 +59,29 @@ def lime_contributions(model,
     lime_contrib = []
 
     for i in x_init.index:
+        if mode == "classification":
+            num_classes = len(classes)
 
-        if mode == "classification" and num_classes <= 2:
+            if num_classes <= 2:
+                exp = explainer.explain_instance(x_init.loc[i], model.predict_proba)
+                lime_contrib.append(dict([[transform_name(var_name[0], x_init), var_name[1]] for var_name in exp.as_list()]))
 
-            exp = explainer.explain_instance(x_init.loc[i], model.predict_proba)
-            lime_contrib.append(dict([[transform_name(var_name[0], x_init), var_name[1]] for var_name in exp.as_list()]))
-
-        elif mode == "classification" and num_classes > 2:
-
-            contribution = []
-            for j in range(num_classes):
-                list_contrib = []
-                df_contrib = pd.DataFrame()
-                for i in x_init.index:
-                    exp = explainer.explain_instance(
-                        x_init.loc[i], model.predict_proba, top_labels=num_classes)
-                    list_contrib.append(
-                        dict([[transform_name(var_name[0], x_init), var_name[1]] for var_name in exp.as_list(j)]))
-                    df_contrib = pd.DataFrame(list_contrib)
-                    df_contrib = df_contrib[list(x_init.columns)]
-                contribution.append(df_contrib.values)
-            return contribution
+            elif num_classes > 2:
+                contribution = []
+                for j in range(num_classes):
+                    list_contrib = []
+                    df_contrib = pd.DataFrame()
+                    for i in x_init.index:
+                        exp = explainer.explain_instance(
+                            x_init.loc[i], model.predict_proba, top_labels=num_classes)
+                        list_contrib.append(
+                            dict([[transform_name(var_name[0], x_init), var_name[1]] for var_name in exp.as_list(j)]))
+                        df_contrib = pd.DataFrame(list_contrib)
+                        df_contrib = df_contrib[list(x_init.columns)]
+                    contribution.append(df_contrib.values)
+                return contribution
 
         else:
-
             exp = explainer.explain_instance(x_init.loc[i], model.predict)
             lime_contrib.append(dict([[transform_name(var_name[0], x_init), var_name[1]] for var_name in exp.as_list()]))
 

--- a/tests/unit_tests/utils/test_lime_backend.py
+++ b/tests/unit_tests/utils/test_lime_backend.py
@@ -38,7 +38,7 @@ class TestLimeBackend(unittest.TestCase):
         for model in self.modellist_classif:
             print(type(model))
             model.fit(self.x_df.values, self.y_df.values)
-            lime_contributions(model, self.x_df, self.x_df, num_classes=2)
+            lime_contributions(model, self.x_df, self.x_df, classes=[0, 1])
 
     def test_lime_contributions_2(self):
         """
@@ -55,7 +55,7 @@ class TestLimeBackend(unittest.TestCase):
         for model in self.modellist_classif:
             print(type(model))
             model.fit(self.x_df1.values, self.y_df1.values)
-            lime_contributions(model, self.x_df1, self.x_df1, num_classes=3)
+            lime_contributions(model, self.x_df1, self.x_df1, classes=[0, 1, 2])
 
     def test_lime_contributions_3(self):
         """


### PR DESCRIPTION
# Description

Bugfix on compute lime for regression
xpl._classes has no lenght

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* OS:Linux
* Python version:3.7
* Shapash version:1.5.0

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
- [x ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules