### PR TITLE
Bug fix : matplotlib 3.5.1

### DIFF
--- a/shapash/explainer/consistency.py
+++ b/shapash/explainer/consistency.py
@@ -396,7 +396,7 @@ class Consistency():
             Distance between the methods
         """
         ax.annotate(
-            s="",
+            "",
             xy=a - 0.05 * (a - b),
             xycoords="data",
             xytext=b + 0.05 * (a - b),
@@ -404,7 +404,7 @@ class Consistency():
             arrowprops=dict(arrowstyle="<->"),
         )
         ax.annotate(
-            s="%.2f" % dst,
+            "%.2f" % dst,
             xy=(0.5 * (a[0] + b[0]), 0.5 * (a[1] + b[1])),
             xycoords="data",
             textcoords="data",


### PR DESCRIPTION
# Description
With the new version of matplotlib 3.5.1, the prototype of the method annotate changed.
The first parameter was called 's' and became 'text'.
The solution is to not precise the name to keep compatibility with the different version.

Fixes #284

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**Test Configuration**:
* OS: linux
* Python version: 3.8
* Shapash version: last version

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules