### PR TITLE
fixed acv version as new version uses skrange which is not compatible with python 3.6

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -34,5 +34,5 @@ seaborn==0.11.1
 notebook
 Jinja2
 phik
-acv-exp
+acv-exp==1.1.2
 lime                 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras['lightgbm'] = ['lightgbm>=2.3.0']
 extras['catboost'] = ['catboost>=0.21']
 extras['scikit-learn'] = ['scikit-learn>=0.23.0']
 extras['category_encoders'] = ['category_encoders==2.2.2']
-extras['acv'] = ['acv-exp']
+extras['acv'] = ['acv-exp==1.1.2']
 extras['lime'] = ['lime']
 
 setup_requirements = ['pytest-runner', ]


### PR DESCRIPTION
# Description
Fixes an issue with new acv version : 
newest acv version depends on skrange which is not compatible with python version 3.6

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)