### PR TITLE
reduce model number in test for multiple classification

### DIFF
--- a/tests/unit_tests/utils/test_lime_backend.py
+++ b/tests/unit_tests/utils/test_lime_backend.py
@@ -52,10 +52,10 @@ class TestLimeBackend(unittest.TestCase):
         self.x_df1 = df[['x1', 'x2']]
         self.y_df1 = df['y'].to_frame()
 
-        for model in self.modellist_classif:
-            print(type(model))
-            model.fit(self.x_df1.values, self.y_df1.values)
-            lime_contributions(model, self.x_df1, self.x_df1, classes=[0, 1, 2])
+        model = ske.ExtraTreesClassifier(n_estimators=1)       
+        print(type(model))
+        model.fit(self.x_df1.values, self.y_df1.values)
+        lime_contributions(model, self.x_df1, self.x_df1, classes=[0, 1, 2])
 
     def test_lime_contributions_3(self):
         """


### PR DESCRIPTION
# Description

Improve test duration by reducing the number of models in test_lime_contributions_2 method

Fixes #315 

## Type of change
- [X] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
I did run 'pytest' command and it takes 05:04 minutes instead of 7 minutes


**Test Configuration**:
*OS: Windows (wsl)
*Python version: : 3.8.10
*Shapash version: 1.6.1

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules