### PR TITLE
bump verison to 1.7.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.7.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ test_requirements = ['pytest', ]
 
 setup(
     name="shapash",
-    version="1.7.0",
+    version="1.7.1",
     python_requires='>3.5, <3.10',
     url='https://github.com/MAIF/shapash',
     author="Yann Golhen, Sebastien Bidault, Yann Lagre, Maxime Gendre",

--- a/shapash/__init__.py
+++ b/shapash/__init__.py
@@ -3,4 +3,4 @@
 
 __author__ = """Yann Golhen, Yann Lagré, Sebastien Bidault, Maxime Gendre, Thomas Bouche, Johann Martin, Guillaume Vignal"""
 __email__ = 'yann.golhen@maif.fr, yann.lagre@maif.fr, sebabstien.bidault.marketing@maif.fr, thomas.bouche@maif.fr, guillaume.vignal@maif.fr'
-__version__ = '1.7.0'
+__version__ = '1.7.1'


### PR DESCRIPTION
Bump version 1.7.0 to 1.7.1

1.7.1 instead of 1.7.0 because colors.json was don't pusn in pypi
#319 