### PR TITLE
Enable compatibility with new version of category-encoders

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 pip==21.3.1
 dash==2.3.1
 catboost==0.26.1
-category-encoders==2.1.0
+category-encoders==2.2.2
 dash-bootstrap-components==1.1.0
 dash-core-components==2.0.0
 dash-daq==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras['xgboost'] = ['xgboost>=1.0.0']
 extras['lightgbm'] = ['lightgbm>=2.3.0']
 extras['catboost'] = ['catboost>=0.21']
 extras['scikit-learn'] = ['scikit-learn>=0.23.0']
-extras['category_encoders'] = ['category_encoders==2.2.2']
+extras['category_encoders'] = ['category_encoders>=2.2.2']
 extras['acv'] = ['acv-exp==1.1.2']
 extras['lime'] = ['lime']
 

--- a/shapash/utils/columntransformer_backend.py
+++ b/shapash/utils/columntransformer_backend.py
@@ -179,6 +179,7 @@ def inv_transform_sklearn_in_ct(x_in, init, name_encoding, col_encoding, ct_enco
     init += nb_col
     return frame, init
 
+
 def calc_inv_contrib_ct(x_contrib, encoding, agg_columns):
     """
     Reversed contribution when ColumnTransformer is used.
@@ -226,7 +227,10 @@ def calc_inv_contrib_ct(x_contrib, encoding, agg_columns):
                         if str(type(ct_encoding)) == sklearn_onehot:
                             col_origin = ct_encoding.categories_[i_enc]
                         elif str(type(ct_encoding)) == category_encoder_binary:
-                            col_origin = ct_encoding.base_n_encoder.mapping[i_enc].get('mapping').columns.tolist()
+                            try:
+                                col_origin = ct_encoding.base_n_encoder.mapping[i_enc].get('mapping').columns.tolist()
+                            except:
+                                col_origin = ct_encoding.mapping[i_enc].get('mapping').columns.tolist()
                         else:
                             col_origin = ct_encoding.mapping[i_enc].get('mapping').columns.tolist()
                         nb_col = len(col_origin)
@@ -292,8 +296,8 @@ def transform_ct(x_in, model, encoding):
 
         elif str(type(model)) in other_model:
             rst = pd.DataFrame(encoding.transform(x_in),
-                                columns=extract_features_model(model, dict_model_feature[str(type(model))]),
-                                index=x_in.index)
+                               columns=extract_features_model(model, dict_model_feature[str(type(model))]),
+                               index=x_in.index)
         else:
             raise ValueError("Model specified isn't supported by Shapash.")
 
@@ -304,6 +308,7 @@ def transform_ct(x_in, model, encoding):
         raise Exception(f"{encoding.__class__.__name__} not supported, no preprocessing done.")
 
     return rst
+
 
 def get_names(name, trans, column, column_transformer):
     """
@@ -347,6 +352,7 @@ def get_names(name, trans, column, column_transformer):
 
     return [name + "__" + f for f in trans.get_feature_names()]
 
+
 def get_feature_names(column_transformer):
     """
     Allow to extract all features names from encoders of the ColumnTransformer once it has been applied.
@@ -369,6 +375,7 @@ def get_feature_names(column_transformer):
         feature_names.extend(get_names(name, trans, column, column_transformer))
 
     return feature_names
+
 
 def get_list_features_names(list_preprocessing, columns_dict):
     """

--- a/tests/unit_tests/utils/test_category_encoders_backend.py
+++ b/tests/unit_tests/utils/test_category_encoders_backend.py
@@ -6,7 +6,6 @@ import pandas as pd
 import numpy as np
 import category_encoders as ce
 import catboost as cb
-import sklearn
 import lightgbm
 import xgboost
 from shapash.utils.transform import inverse_transform, apply_preprocessing, get_col_mapping_ce
@@ -86,7 +85,6 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
                                                list_dict])
 
         pd.testing.assert_frame_equal(expected, original)
-
 
     def test_inverse_transform_3(self):
         """
@@ -404,7 +402,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
                              'BaseN1': ['M', 'N', 'N'], 'BaseN2': ['O', 'P', 'ZZ'],
                              'Target1': ['Q', 'R', 'R'], 'Target2': ['S', 'T', 'ZZ'],
                              'other': ['other', '123', np.nan]},
-                             index=['index1', 'index2', 'index3'])
+                            index=['index1', 'index2', 'index3'])
 
         expected = pd.DataFrame({'Onehot1': ['A', 'B', 'A'], 'Onehot2': ['C', 'D', 'missing'],
                                  'Binary1': ['E', 'F', 'F'], 'Binary2': ['G', 'H', 'missing'],
@@ -412,7 +410,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
                                  'BaseN1': ['M', 'N', 'N'], 'BaseN2': ['O', 'P', np.nan],
                                  'Target1': ['Q', 'R', 'R'], 'Target2': ['S', 'T', 'NaN'],
                                  'other': ['other', '123', np.nan]},
-                             index=['index1', 'index2', 'index3'])
+                                index=['index1', 'index2', 'index3'])
 
         y = pd.DataFrame(data=[0, 1, 0, 0], columns=['y'])
 
@@ -668,7 +666,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
 
         enc = ce.TargetEncoder(cols=['city', 'state'])
-        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+        enc.fit(test, y)
 
         mapping = get_col_mapping_ce(enc)
         expected_mapping = {'city': ['city'], 'state': ['state']}
@@ -685,7 +683,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
 
         enc = ce.OrdinalEncoder(handle_missing='value', handle_unknown='value')
-        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+        enc.fit(test, y)
 
         mapping = get_col_mapping_ce(enc)
         expected_mapping = {'city': ['city'], 'state': ['state'], 'other': ['other']}
@@ -702,7 +700,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
 
         enc = ce.BinaryEncoder(cols=['city', 'state'])
-        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+        enc.fit(test, y)
 
         mapping = get_col_mapping_ce(enc)
         expected_mapping = {'city': ['city_0', 'city_1'], 'state': ['state_0', 'state_1']}
@@ -719,11 +717,15 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
 
         enc = ce.BaseNEncoder(base=2)
-        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+        enc.fit(test, y)
 
         mapping = get_col_mapping_ce(enc)
-        expected_mapping = {'city': ['city_0', 'city_1', 'city_2'], 'state': ['state_0', 'state_1'],
-                            'other': ['other_0', 'other_1']}
+        if ce.__version__ <= '2.2.2':
+            expected_mapping = {'city': ['city_0', 'city_1', 'city_2'], 'state': ['state_0', 'state_1'],
+                                'other': ['other_0', 'other_1']}
+        else:
+            expected_mapping = {'city': ['city_0', 'city_1'], 'state': ['state_0', 'state_1'],
+                                'other': ['other_0', 'other_1']}
 
         self.assertDictEqual(mapping, expected_mapping)
 
@@ -737,7 +739,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
 
         enc = ce.OneHotEncoder(cols=['city', 'state'], use_cat_names=True)
-        test_encoded = pd.DataFrame(enc.fit_transform(test, y))
+        enc.fit(test, y)
 
         mapping = get_col_mapping_ce(enc)
         expected_mapping = {'city': ['city_chicago', 'city_paris'], 'state': ['state_US', 'state_FR']}

--- a/tests/unit_tests/utils/test_columntransformer_backend.py
+++ b/tests/unit_tests/utils/test_columntransformer_backend.py
@@ -14,7 +14,7 @@ import xgboost
 from shapash.utils.transform import inverse_transform
 from shapash.utils.transform import apply_preprocessing
 from shapash.utils.columntransformer_backend import get_feature_names, get_names, get_list_features_names, \
-        get_col_mapping_ct
+    get_col_mapping_ct
 from sklearn.ensemble import GradientBoostingClassifier
 
 
@@ -95,28 +95,28 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         test inv_transform_ct with multiple encoding and dictionnary
         """
         train = pd.DataFrame({'city': ['chicago', 'paris'],
-                                  'state': ['US', 'FR'],
-                                  'other': ['A', 'B']},
-                                 index=['index1', 'index2'])
+                              'state': ['US', 'FR'],
+                              'other': ['A', 'B']},
+                             index=['index1', 'index2'])
 
         enc = ColumnTransformer(
-                transformers=[
-                    ('onehot_ce', ce.OneHotEncoder(), ['city', 'state']),
-                    ('onehot_skp', skp.OneHotEncoder(), ['city', 'state'])
-                ],
-                remainder='passthrough')
+            transformers=[
+                ('onehot_ce', ce.OneHotEncoder(), ['city', 'state']),
+                ('onehot_skp', skp.OneHotEncoder(), ['city', 'state'])
+            ],
+            remainder='passthrough')
         enc.fit(train)
         test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
-                                 'state': ['US', 'FR', 'FR'],
-                                 'other': ['A', 'B', 'C']},
-                                index=['index1', 'index2', 'index3'])
+                             'state': ['US', 'FR', 'FR'],
+                             'other': ['A', 'B', 'C']},
+                            index=['index1', 'index2', 'index3'])
 
         expected = pd.DataFrame({'onehot_ce_city': ['CH', 'CH', 'PR'],
-                                     'onehot_ce_state': ['US-FR', 'US-FR', 'US-FR'],
-                                     'onehot_skp_city': ['chicago', 'chicago', 'paris'],
-                                     'onehot_skp_state': ['US', 'FR', 'FR'],
-                                     'other': ['A-B', 'A-B', 'C']},
-                                    index=['index1', 'index2', 'index3'])
+                                 'onehot_ce_state': ['US-FR', 'US-FR', 'US-FR'],
+                                 'onehot_skp_city': ['chicago', 'chicago', 'paris'],
+                                 'onehot_skp_state': ['US', 'FR', 'FR'],
+                                 'other': ['A-B', 'A-B', 'C']},
+                                index=['index1', 'index2', 'index3'])
 
         result = pd.DataFrame(enc.transform(test))
         result.columns = ['col1_0', 'col1_1', 'col2_0', 'col2_1', 'col3_0', 'col3_1', 'col4_0', 'col4_1', 'other']
@@ -138,7 +138,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         input_dict3['data_type'] = 'object'
         list_dict = [input_dict2, input_dict3]
 
-        original = inverse_transform(result, [enc,input_dict1,list_dict])
+        original = inverse_transform(result, [enc, input_dict1, list_dict])
         pd.testing.assert_frame_equal(original, expected)
 
     def test_inv_transform_ct_4(self):
@@ -193,8 +193,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
                              'other': ['A', 'B', 'C']})
 
         expected = pd.DataFrame(data={
-                    'target_city': ['chicago', 'chicago', 'paris'],
-                    'target_state': ['US', 'FR', 'FR']})
+            'target_city': ['chicago', 'chicago', 'paris'],
+            'target_state': ['US', 'FR', 'FR']})
 
         result = pd.DataFrame(enc.transform(test))
         result.columns = ['col1', 'col2']
@@ -975,10 +975,10 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
                               'other': ['A', 'B']})
 
         enc_1 = ColumnTransformer(transformers=[('Quantile', skp.QuantileTransformer(n_quantiles=2), ['num1', 'num2'])],
-                                remainder='drop')
+                                  remainder='drop')
 
         enc_2 = ColumnTransformer(transformers=[('Quantile', skp.QuantileTransformer(n_quantiles=2), ['num1', 'num2'])],
-                                remainder='passthrough')
+                                  remainder='passthrough')
 
         enc_1.fit(train)
         enc_2.fit(train)
@@ -1126,7 +1126,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         test_encoded = pd.DataFrame(enc.fit_transform(test))
 
         mapping = get_col_mapping_ct(enc, test_encoded)
-        expected_mapping = {'onehot_ce_city': [0, 1], 'onehot_ce_state': [2, 3], 'onehot_skp_city': [4, 5], 'onehot_skp_state': [6, 7]}
+        expected_mapping = {'onehot_ce_city': [0, 1], 'onehot_ce_state': [
+            2, 3], 'onehot_skp_city': [4, 5], 'onehot_skp_state': [6, 7]}
 
         self.assertDictEqual(mapping, expected_mapping)
 
@@ -1164,7 +1165,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
             ],
             remainder='passthrough')
 
-        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'],
+                         index=['index1', 'index2', 'index3'])
         test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
                              'state': ['US', 'FR', 'FR'],
                              'other': ['A', 'B', 'C']},
@@ -1187,7 +1189,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
             ],
             remainder='drop')
 
-        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'],
+                         index=['index1', 'index2', 'index3'])
         test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
                              'state': ['US', 'FR', 'FR'],
                              'other': ['A', 'B', 'C']},
@@ -1210,7 +1213,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
             ],
             remainder='drop')
 
-        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'],
+                         index=['index1', 'index2', 'index3'])
         test = pd.DataFrame({'city': ['chicago', 'chicago', 'paris'],
                              'state': ['US', 'FR', 'FR'],
                              'other': ['A', 'B', 'C']},
@@ -1232,7 +1236,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
             ],
             remainder='drop')
 
-        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'],
+                         index=['index1', 'index2', 'index3'])
         test = pd.DataFrame({'city': ['chicago', 'new york', 'paris'],
                              'state': ['US', 'FR', 'FR'],
                              'other': ['A', 'B', 'C']},
@@ -1240,7 +1245,10 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
 
         test_encoded = pd.DataFrame(enc.fit_transform(test, y))
         mapping = get_col_mapping_ct(enc, test_encoded)
-        expected_mapping = {'basen_city': [0, 1, 2], 'basen_state': [3, 4]}
+        if ce.__version__ <= '2.2.2':
+            expected_mapping = {'basen_city': [0, 1, 2], 'basen_state': [3, 4]}
+        else:
+            expected_mapping = {'basen_city': [0, 1], 'basen_state': [2, 3]}
 
         self.assertDictEqual(mapping, expected_mapping)
 
@@ -1254,7 +1262,8 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
             ],
             remainder='drop')
 
-        y = pd.DataFrame(data=[0, 1, 1], columns=['y'])
+        y = pd.DataFrame(data=[0, 1, 1], columns=['y'],
+                         index=['index1', 'index2', 'index3'])
         test = pd.DataFrame({'city': ['chicago', 'new york', 'paris'],
                              'state': ['US', 'FR', 'FR'],
                              'other': ['A', 'B', 'C']},


### PR DESCRIPTION
It was not possible before to use the latest version of category-encoders because they have done several breaking changes:
- pandas.Series to Dict
- new test on the index of X and y
- classes don't have anymore BaseNEncoder as an attribute but inherit directly from it

# Description

Some modification have been done in the code and in the different test to be able to work indifferently with the different version of category-encoders. In the future, it will be great to support only version of category-encoders > 2.2.2

Fixes #371

## Type of change
- [x] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)

**Test Configuration**:
* OS: linux
* Python version: 3.8
* Shapash version: 2.0.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules