### PR TITLE
Fix python version for readthedocs.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
# Description

Fixes readthedocs with update python from version 3.10 to 3.8. Readthedocs does not support python above 3.9 yet : https://github.com/readthedocs/readthedocs.org/issues/7554

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules