### PR TITLE
fix pandas version until xgboost is fixed and fix other code for pandas

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,7 +10,7 @@ dash-html-components==2.0.0
 dash-renderer==1.8.3
 dash-table==5.0.0
 lightgbm==2.3.1
-pandas>1.0.2
+pandas>1.0.2,<2.0.0
 plotly==5.6.0
 shap>=0.38.1
 Sphinx==4.5.0
@@ -31,7 +31,7 @@ numba>=0.53.1
 nbconvert>=6.0.7
 papermill>=2.0.0
 matplotlib>=3.3.0
-seaborn==0.11.1
+seaborn>=0.12.2
 scipy>=0.19.1
 notebook>=6.0.0
 jupyter-client<8.0.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
     'plotly>=5.0.0',
     'matplotlib>=3.2.0',
     'numpy>1.18.0',
-    'pandas>1.0.2',
+    'pandas>1.0.2,<2.0.0',
     'shap>=0.38.1',
     'dash>=2.3.1',
     'dash-bootstrap-components>=1.1.0',
@@ -43,7 +43,7 @@ extras['report'] = [
     'nbconvert==6.0.7',
     'papermill>=2.0.0',
     'jupyter-client<8.0.0',
-    'seaborn<=0.11.2',
+    'seaborn>=0.12.2',
     'notebook',
     'Jinja2>=2.11.0',
     'phik'

--- a/shapash/explainer/consistency.py
+++ b/shapash/explainer/consistency.py
@@ -547,8 +547,8 @@ class Consistency():
         weights = [weight.drop(const_cols, axis=1) for weight in weights]
 
         # Only keep features based on largest mean of absolute values
-        mean_contributions = np.mean(np.abs(pd.concat(weights)))
-        top_features = np.flip(np.sort(mean_contributions)[::-1][:max_features].keys())
+        mean_contributions = np.mean(np.abs(pd.concat(weights)), axis=0)
+        top_features = np.flip(mean_contributions.sort_values(ascending=False)[:max_features].keys())
 
         fig = self.plot_pairwise_consistency(weights, x, top_features, methods, file_name, auto_open)
 

--- a/shapash/explainer/consistency.py
+++ b/shapash/explainer/consistency.py
@@ -548,7 +548,7 @@ class Consistency():
 
         # Only keep features based on largest mean of absolute values
         mean_contributions = np.mean(np.abs(pd.concat(weights)))
-        top_features = np.flip(mean_contributions.sort_values(ascending=False)[:max_features].keys())
+        top_features = np.flip(np.sort(mean_contributions)[::-1][:max_features].keys())
 
         fig = self.plot_pairwise_consistency(weights, x, top_features, methods, file_name, auto_open)
 

--- a/shapash/report/plots.py
+++ b/shapash/report/plots.py
@@ -175,7 +175,7 @@ def _merge_small_categories(df_cat: pd.DataFrame, col: str, hue: str,  nb_cat_ma
     df_cat_other = df_cat.loc[df_cat[col].isin(list_cat_to_merge)] \
         .groupby(hue, as_index=False)[["count", "Percent"]].sum()
     df_cat_other[col] = "Other"
-    return df_cat.loc[~df_cat[col].isin(list_cat_to_merge)].append(df_cat_other)
+    return pd.concat([df_cat.loc[~df_cat[col].isin(list_cat_to_merge)],df_cat_other], axis=0)
 
 
 def generate_confusion_matrix_plot(

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -351,7 +351,7 @@ class SmartApp:
                 {
                     column: {'value': str(value), 'type': 'text'}
                     for column, value in row.items()
-                } for row in self.dataframe.to_dict('rows')
+                } for row in self.dataframe.to_dict('index').values()
             ], tooltip_duration=2000,
 
             columns=[{"name": i, "id": i} for i in self.dataframe.columns],

--- a/tests/unit_tests/report/test_common.py
+++ b/tests/unit_tests/report/test_common.py
@@ -12,7 +12,7 @@ class TestCommon(unittest.TestCase):
         """
         Test string series
         """
-        s = pd.Series(["a", "b", "c", "d", "e", np.nan])
+        s = pd.Series(["a", "b", "c", "d", "e"])
 
         assert series_dtype(s) == VarType.TYPE_CAT
 

--- a/tests/unit_tests/report/test_data_analysis.py
+++ b/tests/unit_tests/report/test_data_analysis.py
@@ -11,8 +11,8 @@ class TestDataAnalysis(unittest.TestCase):
 
     def test_perform_global_dataframe_analysis_1(self):
         df = pd.DataFrame({
-            "string_data": ["a", "b", "c", "d", "e", np.nan],
-            "bool_data": [True, True, False, False, False, np.nan],
+            "string_data": ["a", "b", "c", "d", "e", "f"],
+            "bool_data": [True, True, False, False, False, False],
             "int_data": [10, 20, 30, 40, 50, 0],
         })
 
@@ -20,8 +20,8 @@ class TestDataAnalysis(unittest.TestCase):
         expected_d = {
             'number of features': '3',
             'number of observations': '6',
-            'missing values': '2',
-            '% missing values': '0.111',
+            'missing values': '0',
+            '% missing values': '0',
         }
         TestCase().assertDictEqual(d, expected_d)
 
@@ -32,8 +32,8 @@ class TestDataAnalysis(unittest.TestCase):
 
     def test_perform_univariate_dataframe_analysis_1(self):
         df = pd.DataFrame({
-            "string_data": ["a", "b", "c", "d", "e", np.nan]*10,
-            "bool_data": [True, True, False, False, False, np.nan]*10,
+            "string_data": ["a", "b", "c", "d", "e", "f"]*10,
+            "bool_data": [True, True, False, False, False, True]*10,
             "int_continuous_data": list(range(60)),
             "float_continuous_data": np.linspace(0, 2, 60),
             "int_cat_data": [1, 1, 1, 2, 2, 2]*10,
@@ -70,12 +70,12 @@ class TestDataAnalysis(unittest.TestCase):
                 'missing values': '0'
             },
             'string_data': {
-                'distinct values': '5',
-                'missing values': '10'
+                'distinct values': '6',
+                'missing values': '0'
             },
             'bool_data': {
                 'distinct values': '2',
-                'missing values': '10'
+                'missing values': '0'
             }
         }
         TestCase().assertDictEqual(d, expected_d)


### PR DESCRIPTION
# Description
There is some code to adapt for the pandas 2.0.0 version
However, xgboost is not yet compatible with pandas version 2.0.0.
Therefore, we will limit the version of pandas in the meantime

Fixes #449 
The main bug on the webapp is fixed

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* OS:Linux
* Python version:3.9
* Shapash version:2.3.0

