### PR TITLE
Fix only shapash numy deprecation.

### DIFF
--- a/shapash/utils/check.py
+++ b/shapash/utils/check.py
@@ -135,13 +135,13 @@ def check_y(x=None, y=None, y_name="y_target"):
         if isinstance(y, pd.DataFrame):
             if y.shape[1] > 1:
                 raise ValueError(f"{y_name} must be a one column pd.Dataframe or pd.Series.")
-            if not (y.dtypes[0] in [np.float, np.int, np.int32, np.float32, np.int64, np.float64]):
+            if not (y.dtypes[0] in [float, int, np.int32, np.float32, np.int64, np.float64]):
                 raise ValueError(f"{y_name} must contain int or float only")
         if isinstance(y, pd.Series):
-            if not (y.dtype in [np.float, np.int, np.int32, np.float32, np.int64, np.float64]):
+            if not (y.dtype in [float, int, np.int32, np.float32, np.int64, np.float64]):
                 raise ValueError(f"{y_name} must contain int or float only")
             y = y.to_frame()
-            if isinstance(y.columns[0], (np.int, np.float)):
+            if isinstance(y.columns[0], (int, float)):
                 y.columns = [y_name]
     return y
 


### PR DESCRIPTION
# Description

Fixes only shapash code dependency with numpy 1.24. However shapash is still not compatible with numpy because of shap.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* OS:Linux
* Python version:3.9
* Shapash version:2.3.3

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules