### PR TITLE
features/dependencies_update

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 pip==21.3.1
-numpy>=1.18.0,<1.24.0
+numpy>=1.18.0
 dash==2.3.1
 catboost>=1.0.1
 category-encoders>=2.6.0
@@ -11,7 +11,7 @@ dash-html-components==2.0.0
 dash-renderer==1.8.3
 dash-table==5.0.0
 lightgbm==2.3.1
-pandas>1.0.2,<2.0.0
+pandas>1.0.2
 plotly==5.6.0
 shap>=0.38.1
 Sphinx==4.5.0
@@ -26,7 +26,7 @@ sphinx_material==0.0.35
 pytest>=6.2.5
 pytest-cov>=2.8.1
 scikit-learn>=1.0.1
-xgboost==1.0.0
+xgboost>=1.0.0
 nbformat>4.2.0
 numba>=0.53.1
 nbconvert>=6.0.7

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ with open(os.path.join(here, 'shapash', "__version__.py")) as f:
 requirements = [
     'plotly>=5.0.0',
     'matplotlib>=3.2.0',
-    'numpy>1.18.0,<1.24.0',
-    'pandas>1.0.2,<2.0.0',
+    'numpy>1.18.0',
+    'pandas>1.0.2',
     'shap>=0.38.1',
     'Flask<2.3.0',
     'dash>=2.3.1',


### PR DESCRIPTION
# Description
Delete limite of version for numpy, pandas and xgboost
Since release of shap and xgboost, it's no longer necessary
Fixes #457 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* OS:Linux
* Python version:3.10
* Shapash version:2.3.4

# Checklist:
Github actions passed