### PR TITLE
Temporary fix numpy version for requirements.dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 pip>=23.2.0
-numpy>=1.18.0
+numpy==1.21.6
 dash==2.3.1
 catboost>=1.0.1
 category-encoders>=2.6.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -39,6 +39,6 @@ jupyter-client<8.0.0
 Jinja2>=2.11.0
 phik>=0.12.0
 skranger>=0.8.0
-acv-exp>=1.1.2
+acv-exp>=1.2.3
 lime>=0.2.0.0
 regex

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-pip==21.3.1
+pip>=23.2.0
 numpy>=1.18.0
 dash==2.3.1
 catboost>=1.0.1


### PR DESCRIPTION
# Description
For tests, requirements.dev do not install correctly. I suggest temporarily fixing the numpy version.

the main problem comes from the ACV dependency which limits the numpy version and which hasn't had a release for 1 year.
If ACV doesn't release a new version of numpy, we'll probably have to remove this dependency.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

