### PR TITLE
fix bug on TreeExplainer selection

### DIFF
--- a/shapash/backend/shap_backend.py
+++ b/shapash/backend/shap_backend.py
@@ -26,7 +26,7 @@ class ShapBackend(BaseBackend):
         else:
             if shap.explainers.Linear.supports_model_with_masker(model, self.masker):
                 self.explainer = shap.Explainer(model=model, masker=self.masker)
-            elif shap.explainers.Tree.supports_model_with_masker(model, self.masker):
+            elif shap.explainers.Tree.supports_model_with_masker(model, None):
                 self.explainer = shap.Explainer(model=model)
             elif shap.explainers.Additive.supports_model_with_masker(model, self.masker):
                 self.explainer = shap.Explainer(model=model, masker=self.masker)


### PR DESCRIPTION
# Description

The masker is put to None when testing if we can use a TreeExplainer.

Fixes #514 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* OS: linux
* Python version: 3.9
* Shapash version: 2.4.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules