### PR TITLE
Hotfix shap 0.45.0

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -13,7 +13,7 @@ dash-table==5.0.0
 lightgbm==2.3.1
 pandas>1.0.2
 plotly==5.6.0
-shap>=0.38.1
+shap>=0.38.1,<0.45.0
 Sphinx==4.5.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "matplotlib>=3.2.0",
     "numpy>1.18.0",
     "pandas>1.0.2",
-    "shap>=0.38.1",
+    "shap>=0.38.1,<0.45.0",
     "Flask<2.3.0",
     "dash>=2.3.1",
     "dash-bootstrap-components>=1.1.0",


### PR DESCRIPTION
Shap has done breaking changes in 0.45.0 version.
Meanwhile we fix it in Shapash, we limit the shap version less than 0.45.0 strictely. 
Fixes #533 
