### PR TITLE
[fix] Issue 554 - ValueError: cannot convert float NaN to integer

### DIFF
--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -193,7 +193,7 @@ class SmartApp:
             typ = self.dataframe[col].dtype
             if typ == float:
                 std = self.dataframe[col].std()
-                if std != 0:
+                if std != 0 and not pd.isna(std):
                     digit = max(round(log10(1 / std) + 1) + 2, 0)
                     self.round_dataframe[col] = self.dataframe[col].map(f"{{:.{digit}f}}".format).astype(float)
 


### PR DESCRIPTION
# Description

Fixes #554 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Change line 196 from:
```python
 if std != 0:
    digit = max(round(log10(1 / std) + 1) + 2, 0)
    self.round_dataframe[col] = self.dataframe[col].map(f"{{:.{digit}f}}".format).astype(float)
```
to
```python
 if std != 0 and not pd.isna(std):
    digit = max(round(log10(1 / std) + 1) + 2, 0)
    self.round_dataframe[col] = self.dataframe[col].map(f"{{:.{digit}f}}".format).astype(float)
```


**Test Configuration**:
* OS: CentOS Linux release 8.2.2.2004
* Python version: python3.10
* Shapash version: shapash-2.5.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
