### PR TITLE
fix documentation generation bug due to numpy 2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 nbsphinx==0.8.8
 sphinx_material==0.0.35
+numpy<2


### PR DESCRIPTION
We fix it right now by forcing a version of numpy<2.0