### PR TITLE
Removed Flask Version Constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "numpy>1.18.0,<2",
     "pandas>=2.1.0",
     "shap>=0.45.0",
-    "Flask>=2.0.0",
+    "Flask>=1.0.4",
     "dash>=2.3.1",
     "dash-bootstrap-components>=1.1.0",
     "dash-core-components>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "numpy>1.18.0,<2",
     "pandas>=2.1.0",
     "shap>=0.45.0",
-    "Flask<2.3.0",
+    "Flask>=2.0.0",
     "dash>=2.3.1",
     "dash-bootstrap-components>=1.1.0",
     "dash-core-components>=2.0.0",


### PR DESCRIPTION
Fixes: #583 

#### Description
This PR removes the Flask version constraint (`<2.3.0`) from `shapash` as the underlying issue related to compatibility with `dash` has been resolved. The latest versions of `dash` now fully support Flask versions 2.3.0 and above.

#### Key Changes:
- **Updated Flask Dependency**: The restriction on Flask (`Flask<2.3.0`) has been removed. 
- **Tested with Latest Flask and Dash**: Compatibility testing was done using the latest versions of both Flask and Dash to ensure the project works seamlessly with updated libraries.

#### Benefits:
- **Security Improvements**: Removing the version constraint allows the use of the latest Flask versions, which include important security updates.
- **Compatibility**: Users can now use `shapash` in environments where Flask versions 2.3.0 or above are required, improving flexibility.
- **Performance Enhancements**: Newer versions of Flask come with performance optimizations that the project can now benefit from.
