### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shapash"
-version = "2.7.0"
+version = "2.7.1"
 authors = [
     {name = "Yann Golhen"},
     {name = "Sebastien Bidault"},
@@ -86,14 +86,14 @@ all = ["shapash[dev, test, mypy, ruff, report, xgboost, lightgbm, catboost, lime
 Homepage = "https://github.com/MAIF/shapash"
 
 [tool.setuptools]
-package-dir = {"" = "shapash"}
+package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]
-where = ["shapash"]
+where = ["."]
 
 
 [tool.setuptools.package-data]
-"shapash" = ["*.csv", "*json", "*.yml", "*.css", "*.js", "*.png"]
+"*" = ["*.csv", "*json", "*.yml", "*.css", "*.js", "*.png"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/shapash/__version__.py
+++ b/shapash/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (2, 6, 0)
+VERSION = (2, 7, 1)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Fixes: #591 
- Fix **pyproject.toml** (invalid folder to build package)
- Bump version to **2.7.1**