### PR TITLE
fix bugs 2.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ where = ["."]
 
 
 [tool.setuptools.package-data]
-"*" = ["*.csv", "*json", "*.yml", "*.css", "*.js", "*.png"]
+"*" = ["*.csv", "*json", "*.yml", "*.css", "*.js", "*.png", "*.ico"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/shapash/plots/plot_bar_chart.py
+++ b/shapash/plots/plot_bar_chart.py
@@ -103,14 +103,16 @@ def plot_bar_chart(
         bars = []
         for num, expl in enumerate(zip(var_dict, x_val, contrib)):
             feat_name, x_val_el, contrib_value = expl
-            group_name = inv_features_dict.get(feat_name)
+            is_grouped = False
             if x_val_el == "":
                 ylabel = f"<i>{feat_name}</i>"
                 hoverlabel = f"<b>{feat_name}</b>"
             else:
                 # If bar is a group of features, hovertext includes the values of the features of the group
                 # And color changes
+                group_name = inv_features_dict.get(feat_name)
                 if features_groups is not None and group_name in features_groups.keys() and len(index_value) > 0:
+                    is_grouped = True
                     feat_groups_values = x_init[features_groups[group_name]].loc[index_value[0]]
                     hoverlabel = "<br />".join(
                         [
@@ -146,7 +148,7 @@ def plot_bar_chart(
                 color = -1 if x_val_el != "" else -2
 
             # If the bar is a group of features we modify the color
-            if group_name is not None:
+            if is_grouped:
                 bar_color = style_dict["featureimp_groups"][0] if color == 1 else style_dict["featureimp_groups"][1]
             else:
                 bar_color = dict_local_plot_colors[color]["color"]

--- a/shapash/plots/plot_scatter_prediction.py
+++ b/shapash/plots/plot_scatter_prediction.py
@@ -220,7 +220,6 @@ def _prediction_classification_plot(
         df_pred = pd.concat(
             [y_proba_values.reset_index(), y_pred.reset_index(drop=True), target.reset_index(drop=True)], axis=1
         )
-        print(df_pred)
         df_pred.set_index(df_pred.columns[0], inplace=True)
         df_pred.columns = ["proba_values", "predict_class", "target"]
         df_pred["wrong_predict"] = 1

--- a/shapash/webapp/utils/callbacks.py
+++ b/shapash/webapp/utils/callbacks.py
@@ -833,8 +833,12 @@ def determine_total_pages_and_display(
         Tuple[int, str, int]: Total pages, display properties, and updated page number.
     """
     display_groups = explainer.features_groups is not None and bool_group
-    nb_features = len(explainer.features_imp_groups) if display_groups else len(explainer.features_imp)
-    total_pages = nb_features // features + 1
+    if explainer._case == "classification":
+        nb_features = len(explainer.features_imp_groups[0]) if display_groups else len(explainer.features_imp[0])
+    elif explainer._case == "regression":
+        nb_features = len(explainer.features_imp_groups) if display_groups else len(explainer.features_imp)
+
+    total_pages = (nb_features - 1) // features + 1
     if (total_pages == 1) or (group_name):
         display_page = {"display": "none"}
     else:


### PR DESCRIPTION
Fixes: #593, #594 #595 #596

This PR addresses and resolves the following issues:

1. #596
   - Fixed the bug related to incorrect default colors being displayed in local explanation plots.

2. #595
   - Corrected the pagination functionality to handle cases where the number of features breaks pagination.

3. #594
   - Restored the correct Shapash icon in the webapp, replacing the unintended dash icon.

4. #593
   - Resolved the issue of the dataframe being printed unnecessarily in `plot_scatter_prediction.py`.
