### PR TITLE
Fix for Feature Importance Local Plot Failure After Global Plot

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -951,6 +951,9 @@ class SmartExplainer:
             contributions=self.contributions, explain_data=self.explain_data, subset=None, norm=1
         )
 
+        if self.features_groups is not None and self.features_imp_groups is None:
+            self.features_imp_groups = self.state.compute_features_import(self.contributions_groups, norm=1)
+
         if local:
             self.features_imp_local_lev1 = self.backend.get_global_features_importance(
                 contributions=self.contributions, explain_data=self.explain_data, subset=None, norm=3
@@ -958,10 +961,7 @@ class SmartExplainer:
             self.features_imp_local_lev2 = self.backend.get_global_features_importance(
                 contributions=self.contributions, explain_data=self.explain_data, subset=None, norm=7
             )
-
-        if self.features_groups is not None and self.features_imp_groups is None:
-            self.features_imp_groups = self.state.compute_features_import(self.contributions_groups, norm=1)
-            if local:
+            if self.features_groups is not None:
                 self.features_imp_groups_local_lev1 = self.state.compute_features_import(
                     self.contributions_groups, norm=3
                 )


### PR DESCRIPTION
Fixes #604 

### **Description**:  
This PR addresses a bug in Shapash where plotting the **feature importance local plot** after the **feature importance global plot** leads to a failure due to missing value computations. The issue arises when the necessary values for the local plot are not computed or stored after rendering the global plot.

### **Changes Made**:
- **Ensure Value Computation**:  
  Adjusted the workflow to ensure that all required values for the local feature importance plot are computed and stored when plotting the local plot.
  
- **Separation of Computations**:  
  Modified the logic to ensure that both the global and local plots can be rendered independently or sequentially without causing any conflicts or missing computations.
