### PR TITLE
Limit scikit-learn version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "dash-table>=5.0.0",
     "nbformat>4.2.0",
     "numba>=0.53.1",
-    "scikit-learn>=1.4.0",
+    "scikit-learn>=1.4.0,<1.6.0",
     "category_encoders>=2.6.0",
     "scipy>=0.19.1",
 ]

--- a/shapash/__version__.py
+++ b/shapash/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (2, 7, 4)
+VERSION = (2, 7, 5)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Category Encoders last Python 3.9 version does not support scikit-learn 1.6.0.