### PR TITLE
Update pre-commit file to remove restriction no commit to branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-ast
     -   id: fix-byte-order-marker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,6 @@ repos:
         exclude: ^(docs/|gdocs/)
     -   id: check-added-large-files
         args: ['--maxkb=500']
-    -   id: no-commit-to-branch
-        args: ['--branch', 'master', '--branch', 'develop']
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.2
     hooks:


### PR DESCRIPTION
Delete restriction no commit to branch for Github Actions.
Upgrade pre-commit-hooks version.