### PR TITLE
Add Option to Display Interaction Plot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shapash"
-version = "2.7.6"
+version = "2.7.7"
 authors = [
     {name = "Yann Golhen"},
     {name = "Sebastien Bidault"},
@@ -29,7 +29,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "plotly>=5.0.0",
+    "plotly>=5.0.0,<6.0.0",
     "matplotlib>=3.2.0",
     "numpy>1.18.0,<2",
     "pandas>=2.1.0",

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1206,6 +1206,7 @@ class SmartExplainer:
         notebook_path=None,
         kernel_name=None,
         max_points=200,
+        display_interaction_plot=False,
         nb_top_interactions=5,
     ):
         """
@@ -1251,6 +1252,9 @@ class SmartExplainer:
             by default.
         max_points : int, optional
             number of maximum points in the contribution plot
+        display_interaction_plot: bool, optional
+            Whether to display the interaction plot. This can be computationally expensive,
+            so it is set to False by default to optimize performance.
         nb_top_interactions : int
             Number of top interactions to display.
         Examples
@@ -1305,6 +1309,7 @@ class SmartExplainer:
                     title_description=title_description,
                     metrics=metrics,
                     max_points=max_points,
+                    display_interaction_plot=display_interaction_plot,
                     nb_top_interactions=nb_top_interactions,
                 ),
                 notebook_path=notebook_path,


### PR DESCRIPTION
Fixes #619 
Fixes #620 

**Description:**
We introduce a new feature that allows users to enable or disable the interaction plot. Previously, the interaction plot was always computed, which could be computationally expensive. By adding this option, users have better control over performance.
We temporarily restrict Plotly to versions below 6.0.0 due to unexpected bugs occurring randomly in certain Python environments. Until these issues are better understood and addressed, staying on a stable version is recommended to ensure smooth functionality.

### **Impact:**
- Improves performance by avoiding unnecessary computations.
- Provides users with more control over their output.
- Enhances usability and scalability for large datasets.
- Prevents users from encountering instability caused by Plotly 6.0.0.
- Maintains compatibility with existing functionality.
- Reduces potential debugging efforts due to unexplained bugs. 

### **Additional Context:**
This enhancement allows users to decide whether to compute and display the interaction plot based on their needs, optimizing the user experience and resource utilization

