### PR TITLE
Fix `display_model_analysis` in Shapash Report to correctly retrieve `sklearn` version

### DIFF
--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -235,13 +235,20 @@ class ProjectReport:
         print_md(f"**Library :** {self.explainer.model.__class__.__module__}")
 
         for _, module in sorted(sys.modules.items()):
+            if not hasattr(module, "__name__"):
+                continue
+
             module_name = module.__name__.split(".")[0]
-            if self.explainer.model.__class__.__module__.split(".")[0] == module_name:
+            expected_name = self.explainer.model.__class__.__module__.split(".")[0]
+
+            if expected_name == module_name:
                 try:
-                    version = importlib.metadata.version(module_name)
+                    package_name = "scikit-learn" if module_name == "sklearn" else module_name
+                    version = importlib.metadata.version(package_name)
                     print_md(f"**Library version :** {version}")
                 except importlib.metadata.PackageNotFoundError:
                     print_md(f"**Library version :** not found for {module_name}")
+                break
 
         print_md("**Model parameters :** ")
         model_params = self.explainer.model.__dict__


### PR DESCRIPTION
Fixes: #627 

**Description:**  
This PR addresses an issue in the **Shapash Report functionality**, where the method `display_model_analysis()` fails to retrieve the correct **library version** when the model comes from `scikit-learn`.  

### **Issue:**  
The function uses `importlib.metadata.version(module_name)`, but `sklearn` is **not the package name in PyPI** (which is `scikit-learn`). This causes the function to return "Library version: not found".  

### **Fix:**  
- **Check if the detected module is `sklearn`** and replace it with `"scikit-learn"` before calling `importlib.metadata.version()`.  
- **Add a safeguard** to **skip modules without a `__name__` attribute** to prevent potential attribute errors.  
