### PR TITLE
Refactor deprecated typing.List and typing.Tuple usage

### DIFF
--- a/shapash/backend/base_backend.py
+++ b/shapash/backend/base_backend.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -68,8 +68,8 @@ class BaseBackend(ABC):
         )
 
     def get_local_contributions(
-        self, x: pd.DataFrame, explain_data: Any, subset: Optional[List[int]] = None
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        self, x: pd.DataFrame, explain_data: Any, subset: Optional[list[int]] = None
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """Get local contributions using the explainer data computed in the `run_explainer`
         method.
 
@@ -110,9 +110,9 @@ class BaseBackend(ABC):
         self,
         contributions: pd.DataFrame,
         explain_data: Optional[dict] = None,
-        subset: Optional[List[int]] = None,
+        subset: Optional[list[int]] = None,
         norm: int = 1,
-    ) -> Union[pd.Series, List[pd.Series]]:
+    ) -> Union[pd.Series, list[pd.Series]]:
         """Get global contributions using the explainer data computed in the `run_explainer`
         method.
 
@@ -141,8 +141,8 @@ class BaseBackend(ABC):
     def format_and_aggregate_local_contributions(
         self,
         x: pd.DataFrame,
-        contributions: Union[pd.DataFrame, np.array, List[pd.DataFrame], List[np.array]],
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        contributions: Union[pd.DataFrame, np.array, list[pd.DataFrame], list[np.array]],
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """
         This function allows to format and aggregate contributions in the right format
         (pd.DataFrame or list of pd.DataFrame).
@@ -175,8 +175,8 @@ class BaseBackend(ABC):
         return contributions
 
     def _apply_preprocessing(
-        self, contributions: Union[pd.DataFrame, List[pd.DataFrame]]
-    ) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        self, contributions: Union[pd.DataFrame, list[pd.DataFrame]]
+    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
         """
         Reconstruct contributions for original features, taken into account a preprocessing.
 

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -692,7 +692,7 @@ class SmartExplainer:
         Features names can be part of columns_dict or features_dict.
         Parameters
         ----------
-        features : List
+        features : list
             List of ints (columns ids) or of strings (business names)
         use_groups : bool
             Whether or not features parameter includes groups of features

--- a/shapash/explainer/smart_predictor.py
+++ b/shapash/explainer/smart_predictor.py
@@ -748,7 +748,7 @@ class SmartPredictor:
 
         Parameters
         ----------
-        features : List
+        features : list
             List of ints (columns ids) or of strings (business names)
 
         Returns

--- a/shapash/explainer/smart_state.py
+++ b/shapash/explainer/smart_state.py
@@ -154,7 +154,7 @@ class SmartState:
         var_dict: pd.DataFrame
             Dataframe with features indexes ordered
             by contribution.
-        feature_list: List
+        feature_list: list
             List of index, feature to hide.
 
         Returns

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -4,7 +4,7 @@ import os
 import sys
 from datetime import date
 from numbers import Number
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import jinja2
 import numpy as np
@@ -137,7 +137,7 @@ class ProjectReport:
     @staticmethod
     def _get_values_and_name(
         y: Optional[Union[pd.DataFrame, pd.Series, list]], default_name: str
-    ) -> Union[Tuple[list, str], Tuple[None, None]]:
+    ) -> Union[tuple[list, str], tuple[None, None]]:
         """
         Extracts vales and column name from a Pandas Series, DataFrame, or assign a default
         name if y is a list of values.

--- a/shapash/utils/check.py
+++ b/shapash/utils/check.py
@@ -422,7 +422,7 @@ def check_features_name(columns_dict, features_dict, features):
 
     Parameters
     ----------
-    features : List
+    features : list
         List of ints (columns ids) or of strings (business names)
     columns_dict: dict
     Dictionary mapping integer column number to technical feature names.

--- a/shapash/utils/model.py
+++ b/shapash/utils/model.py
@@ -14,7 +14,7 @@ def extract_features_model(model, model_attribute):
      -------
     model: model object
         model used to check the different values of target estimate predict proba
-    model_attribute: String or List
+    model_attribute: String or list
         if model can give features, attributes to access features, if not 'length'
     """
     if model_attribute[0] == "length":

--- a/shapash/utils/transform.py
+++ b/shapash/utils/transform.py
@@ -138,7 +138,7 @@ def preprocessing_tolist(preprocess):
 
     Returns
     -------
-    List
+    list
         A list containing all preprocessing.
     """
     list_encoding = preprocess if isinstance(preprocess, list) else [preprocess]

--- a/shapash/utils/translate.py
+++ b/shapash/utils/translate.py
@@ -16,7 +16,7 @@ def translate(elements, mapping):
 
     Returns
     -------
-    List
+    list
         The list of business names (strings) obtained.
     """
     return [mapping[element] for element in elements]

--- a/shapash/webapp/utils/callbacks.py
+++ b/shapash/webapp/utils/callbacks.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from shapash.explainer.smart_explainer import SmartExplainer
@@ -335,7 +335,7 @@ def get_feature_contributions_sign_to_show(positive: list, negative: list) -> Op
     return sign
 
 
-def update_features_to_display(features: int, nb_columns: int, value: int) -> Tuple[int, int, dict]:
+def update_features_to_display(features: int, nb_columns: int, value: int) -> tuple[int, int, dict]:
     """Update features to display slider.
 
     Parameters
@@ -349,7 +349,7 @@ def update_features_to_display(features: int, nb_columns: int, value: int) -> Tu
 
     Returns
     -------
-    Tuple[int, int, dict]
+    tuple[int, int, dict]
         Number of columns to plot, Number max of columns to plot, Marks in the slider
     """
     max_value = min(features, nb_columns)
@@ -696,7 +696,7 @@ def create_filter_modalities_selection(value: str, id: dict, round_dataframe: pd
     return new_element
 
 
-def handle_page_navigation(triggered_input: str, page: Union[int, str], selected_feature: str) -> Tuple[int, str]:
+def handle_page_navigation(triggered_input: str, page: Union[int, str], selected_feature: str) -> tuple[int, str]:
     """
     Handle the navigation between different pages based on user input.
 
@@ -706,7 +706,7 @@ def handle_page_navigation(triggered_input: str, page: Union[int, str], selected
         selected_feature (str): The currently selected feature.
 
     Returns:
-        Tuple[int, str]: Updated page number and selected feature.
+        tuple[int, str]: Updated page number and selected feature.
     """
     page = int(page)
     if triggered_input == "page_left.n_clicks":
@@ -765,7 +765,7 @@ def handle_group_display_logic(
     selected_click_data_store,
     features_groups: dict,
     features_dict: dict,
-) -> Tuple[str, str, dict]:
+) -> tuple[str, str, dict]:
     """
     Handle the display logic for feature groups.
 
@@ -779,7 +779,7 @@ def handle_group_display_logic(
         features_dict (dict): Dictionary of features.
 
     Returns:
-        Tuple[str, str, dict]: Updated selected feature, group name, and click data.
+        tuple[str, str, dict]: Updated selected feature, group name, and click data.
     """
     group_name = None
     selected_feature_group = None
@@ -818,7 +818,7 @@ def handle_group_display_logic(
 
 def determine_total_pages_and_display(
     explainer: "SmartExplainer", features: int, bool_group: bool, group_name: str, page: int
-) -> Tuple[int, str, int]:
+) -> tuple[int, str, int]:
     """
     Determine the total number of pages and the display properties.
 
@@ -830,7 +830,7 @@ def determine_total_pages_and_display(
         page (int): Current page number.
 
     Returns:
-        Tuple[int, str, int]: Total pages, display properties, and updated page number.
+        tuple[int, str, int]: Total pages, display properties, and updated page number.
     """
     display_groups = explainer.features_groups is not None and bool_group
     if explainer._case == "classification":


### PR DESCRIPTION
**Description:**  
This PR addresses deprecation warnings raised by the `ruff` linter regarding the use of `typing.List` and `typing.Tuple`. These are now considered outdated in favor of the built-in `list` and `tuple` type hints (PEP 585), and updating them helps ensure forward compatibility and cleaner code.

### Changes made:
- Replaced `List[...]` with `list[...]` across all affected files.
- Replaced `Tuple[...]` with `tuple[...]` where applicable.
- Removed unused or redundant imports of `List` and `Tuple` from the `typing` module.

### Linting and Pre-commit:
- Ran `pre-commit` hooks with success after changes.
- No functional changes were made; this is strictly a type hint and formatting update.
