### PR TITLE
Fix Date Filtering and Improve Boolean Type Handling in Shapash Webapp

### DIFF
--- a/shapash/webapp/utils/callbacks.py
+++ b/shapash/webapp/utils/callbacks.py
@@ -635,10 +635,10 @@ def create_filter_modalities_selection(value: str, id: dict, round_dataframe: pd
     html.Div
         Div containing the modalities selection options
     """
-    if type(round_dataframe[value].iloc[0]) == bool:
+    if type(round_dataframe[value].iloc[0]) is np.bool_:
         new_element = html.Div(
             dcc.RadioItems(
-                [{"label": val, "value": val} for val in round_dataframe[value].unique()],
+                [{"label": str(val), "value": val} for val in round_dataframe[value].unique()],
                 id={"type": "dynamic-bool", "index": id["index"]},
                 value=round_dataframe[value].iloc[0],
                 inline=False,
@@ -659,17 +659,16 @@ def create_filter_modalities_selection(value: str, id: dict, round_dataframe: pd
     elif (type(round_dataframe[value].iloc[0]) is pd.Timestamp) | (
         type(round_dataframe[value].iloc[0]) is datetime.datetime
     ):
-        new_element = (
-            html.Div(
-                dcc.DatePickerRange(
-                    id={"type": "dynamic-date", "index": id["index"]},
-                    min_date_allowed=round_dataframe[value].min(),
-                    max_date_allowed=round_dataframe[value].max(),
-                    start_date=round_dataframe[value].min(),
-                    end_date=round_dataframe[value].max(),
-                ),
-                style={"width": "65%", "margin-left": "20px"},
+        new_element = html.Div(
+            dcc.DatePickerRange(
+                id={"type": "dynamic-date", "index": id["index"]},
+                min_date_allowed=round_dataframe[value].min(),
+                max_date_allowed=round_dataframe[value].max(),
+                start_date=round_dataframe[value].min(),
+                end_date=round_dataframe[value].max(),
+                clearable=True,
             ),
+            style={"width": "65%", "margin-left": "20px"},
         )
     else:
         lower_value = 0


### PR DESCRIPTION
#### Description:
This PR resolves two issues affecting the filtering functionality in the Shapash Dash web application:

1. **Date Filter Not Working Properly:**  
   When filtering on a date column, no results were returned. This was due to  an incorrect list structure leading to 
   a nested list in `dcc.DatePickerRange` component.
   In addition to this change, i add the `clearable` option to allow users to easily reset the selected date range.

2. **Incorrect Type Check for Boolean Columns:**  
   The existing type check for boolean columns used `type(x) == bool`, which fails when pandas stores booleans as 
  `numpy.bool_`. This PR also update the check to use `type(x) is np.bool_`, making it compatible with typical pandas 
  DataFrame behavior.

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
