### PR TITLE
Upgrade: Add Support for `numpy>=2.0.0` and Modernize Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ classifiers = [
 ]
 dependencies = [
     "plotly>=5.0.0,<6.0.0",
-    "matplotlib>=3.2.0",
-    "numpy>1.18.0,<2",
-    "pandas>=2.1.0",
-    "shap>=0.45.0",
+    "matplotlib>=3.8.4",
+    "numpy>=2.0.0",
+    "pandas>=2.2.2",
+    "shap>=0.46.0",
     "Flask>=1.0.4",
     "dash>=2.3.1,<3.0.0",
     "dash-bootstrap-components>=1.1.0",
@@ -43,25 +43,26 @@ dependencies = [
     "dash-html-components>=2.0.0",
     "dash-renderer==1.8.3",
     "dash-table>=5.0.0",
-    "nbformat>4.2.0",
-    "numba>=0.53.1",
-    "scikit-learn>=1.4.0,<1.6.0",
+    "nbformat>5.8.0",
+    "numba>=0.60.0",
+    "scikit-learn>=1.4.2,<1.6.0",
     "category_encoders>=2.6.0",
-    "scipy>=0.19.1",
+    "scipy>=1.13.0",
 ]
 
 [project.optional-dependencies] # Optional
 report = [
-    "nbconvert>=6.0.7",
-    "papermill>=2.0.0",
-    "jupyter-client>=7.4.0",
-    "notebook",
-    "Jinja2>=2.11.0",
-    "phik",
+    "nbconvert>=7.2.0",
+    "papermill>=2.5.0",
+    "jupyter-client>=8.3.0",
+    "notebook>=7.0.0",
+    "Jinja2>=3.1.0",
+    "phik>=0.12.4",
+    "pyarrow>=17.0.0",
 ]
-xgboost = ["xgboost>=1.0.0"]
-lightgbm = ["lightgbm>=2.3.0"]
-catboost = ["catboost>=1.0.1"]
+xgboost = ["xgboost>=2.1.0"]
+lightgbm = ["lightgbm>=4.4.0"]
+catboost = ["catboost>=1.2.8"]
 lime = ["lime>=0.2.0.0"]
 
 dev = ["pre-commit", "mypy", "ruff"]


### PR DESCRIPTION
Fixes #558 

### Summary

This PR upgrades **Shapash** and its dependencies to support **NumPy ≥ 2.0.0** and the modern Python data science stack.
NumPy 2.0 introduced breaking ABI and API changes — several internal libraries required version bumps or code updates to maintain compatibility. This PR updates `pyproject.toml` and optional dependencies accordingly.

### Background

NumPy 2.0 introduced several major changes:

* Removal of legacy aliases (`np.int`, `np.bool`, etc.)
* Changes in internal `_ARRAY_API`
* Updated binary interface (ABI) requiring downstream libraries to be rebuilt

Without these updates, Shapash and its dependencies could fail with errors like:

```
AttributeError: _ARRAY_API not found
```

or segfaults in compiled extensions.

### Changes in this PR

#### Core dependency updates (`pyproject.toml`):

* **numpy** → `>=2.0.0`
* **matplotlib** → `>=3.8.4`
* **pandas** → `>=2.2.2`
* **shap** → `>=0.46.0`
* **numba** → `>=0.60.0`
* **scikit-learn** → `>=1.4.2`
* **scipy** → `>=1.13.0`

#### Optional report stack updates:

* **nbconvert** → `>=7.2.0`
* **papermill** → `>=2.5.0`
* **jupyter-client** → `>=8.3.0`
* **notebook** → `>=7.0.0`
* **Jinja2** → `>=3.1.0`
* **phik** → `>=0.12.4`
* **pyarrow** → `>=17.0.0`

#### ML backend updates:

* **lightgbm** → `>=4.4.0`
* **catboost** → `>=1.2.8`
* **xgboost** → `>=2.1.0`

These changes ensure all C/C++ extensions are compiled with support for the NumPy 2 ABI.

### ⚠️ Notes for Users

* Some libraries (`pyarrow`, `phik`, `lightgbm`) **must be reinstalled or rebuilt** to work with NumPy 2.x.
* If you encounter `_ARRAY_API not found`, please upgrade `pyarrow` and `phik`:

```bash
pip install --upgrade pyarrow>=17.0.0 phik>=0.12.4
```

* `numpy<2` is no longer supported.
