### PR TITLE
Replace t-SNE with UMAP as default 1D projection method and fix metadata alignment bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,47 +30,49 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "plotly>=5.0.0,<6.0.0",
-    "matplotlib>=3.8.4",
-    "numpy>=2.0.0",
-    "pandas>=2.2.2",
-    "shap>=0.46.0",
-    "Flask>=1.0.4",
-    "dash>=2.3.1,<3.0.0",
+    "category_encoders>=2.6.0",
     "dash-bootstrap-components>=1.1.0",
     "dash-core-components>=2.0.0",
     "dash-daq>=0.5.0",
     "dash-html-components>=2.0.0",
     "dash-renderer==1.8.3",
     "dash-table>=5.0.0",
+    "dash>=2.3.1,<3.0.0",
+    "Flask>=1.0.4",
+    "matplotlib>=3.8.4",
     "nbformat>5.8.0",
     "numba>=0.60.0",
+    "numpy>=2.0.0",
+    "pandas>=2.2.2",
+    "plotly>=5.0.0,<6.0.0",
     "scikit-learn>=1.4.2,<1.6.0",
-    "category_encoders>=2.6.0",
     "scipy>=1.13.0",
+    "shap>=0.46.0",
+    "umap-learn>=0.5.7",
 ]
 
 [project.optional-dependencies] # Optional
 report = [
-    "nbconvert>=7.2.0",
-    "papermill>=2.5.0",
-    "jupyter-client>=8.3.0",
-    "notebook>=7.0.0",
     "Jinja2>=3.1.0",
+    "jupyter-client>=8.3.0",
+    "nbconvert>=7.2.0",
+    "notebook>=7.0.0",
+    "papermill>=2.5.0",
     "phik>=0.12.4",
     "pyarrow>=17.0.0",
 ]
 xgboost = ["xgboost>=2.1.0"]
-lightgbm = ["lightgbm>=4.4.0"]
 catboost = ["catboost>=1.2.8"]
+lightgbm = ["lightgbm>=4.4.0"]
 lime = ["lime>=0.2.0.0"]
-umap = ["umap-learn>=0.5.7"]
 
 dev = ["pre-commit", "mypy", "ruff"]
 test = ["pytest", "pytest-cov"]
 mypy = ["mypy"]
 ruff = ["ruff"]
 doc = [
+    "nbsphinx==0.8.8",
+    "sphinx_material==0.0.35",
     "Sphinx==4.5.0",
     "sphinxcontrib-applehelp==1.0.2",
     "sphinxcontrib-devhelp==1.0.2",
@@ -78,11 +80,9 @@ doc = [
     "sphinxcontrib-jsmath==1.0.1",
     "sphinxcontrib-qthelp==1.0.3",
     "sphinxcontrib-serializinghtml==1.1.5",
-    "nbsphinx==0.8.8",
-    "sphinx_material==0.0.35",
 ]
 
-all = ["shapash[dev, test, mypy, ruff, report, xgboost, lightgbm, catboost, lime, doc, umap]"]
+all = ["shapash[dev, test, mypy, ruff, report, xgboost, lightgbm, catboost, lime, doc]"]
 
 [project.urls]
 Homepage = "https://github.com/MAIF/shapash"

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -552,10 +552,10 @@ class SmartPlotter:
                 features_imp.loc[self._explainer.features_groups[col]].sort_values(ascending=False)[:4].index
             )  # Displaying top 4 features
             metadata = {
-                self._explainer.features_dict[f_name]: self._explainer.x_init[f_name]
+                self._explainer.features_dict[f_name]: self._explainer.x_init.loc[list_ind, f_name]
                 for f_name in top_features_of_group
             }
-            text_group = "Features values were projected on the x axis using t-SNE"
+            text_group = "Features values were projected on the x axis using Umap"
             # if group don't show addnote, if not, it's too long
             # if addnote is not None:
             #    addnote = add_text([addnote, text_group], sep=' - ')

--- a/shapash/plots/plot_contribution.py
+++ b/shapash/plots/plot_contribution.py
@@ -94,10 +94,18 @@ def plot_scatter(
         hv_text = [f"Id: {x}" for x in feature_values.index]
 
     if metadata:
-        metadata = {k: [round_to_k(x, 3) if isinstance(x, Number) else x for x in v] for k, v in metadata.items()}
-        text_groups_features = np.swap = np.array([col_values for col_values in metadata.values()])
+        metadata = {
+            k: [
+                round_to_k(x, 3) if isinstance(x, Number) else x
+                for x in pd.Series(v, index=feature_values.index).reindex(feature_values.index)
+            ]
+            for k, v in metadata.items()
+        }
+
+        text_groups_features = np.array([col_values for col_values in metadata.values()])
         text_groups_features = np.swapaxes(text_groups_features, 0, 1)
         text_groups_features_keys = list(metadata.keys())
+
         hovertemplate = (
             "<b>%{hovertext}</b><br />"
             + "Contribution: %{y:.4f} <br />"


### PR DESCRIPTION
Fixes #647 

This PR introduces two main improvements to the feature projection and visualization code:

1. **UMAP is now the default projection method** instead of t-SNE in `project_feature_values_1d()`.
2. **Bug fix**: Ensures that `hovertext` and `hovertemplate` are properly aligned by reindexing `metadata` according to `feature_values.index`.

## Changes

### 1. Use UMAP by default

* `how` parameter in `project_feature_values_1d()` now defaults to `"umap"` instead of `"tsne"`.
* Added a new `elif how == "umap"` branch that uses `umap.UMAP` with `n_components=1`.

### 2. Fix hovertext/hovertemplate index alignment bug

Previously, `hovertext` and `hovertemplate` were get out of sync because `metadata` haven't the same index order as `feature_values`.
This caused tooltips in Plotly visualizations to display incorrect information.

**Fix:**

* Convert `metadata` into a DataFrame or Series and **reindex it** based on `feature_values.index`.
* Build `text_groups_features` after reindexing, ensuring perfect row-level alignment.

## Impact

* Improves performance and scalability of feature projections (UMAP is faster and handles high-dimensional data better than t-SNE).
* Fixes a subtle but impactful visualization bug in tooltips.
