### PR TITLE
Synchronize `features_dict` with dataset columns

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -716,10 +716,20 @@ class SmartExplainer:
 
     def check_features_dict(self):
         """
-        Check the features_dict and add the necessary keys if all the
-        input X columns are not present
+        Synchronize features_dict with dataset columns:
+        - Remove features not present in dataset
+        - Add missing dataset features to features_dict
         """
-        for feature in set(list(self.columns_dict.values())) - set(list(self.features_dict)):
+
+        dataset_features = set(self.columns_dict.values())
+        current_features = set(self.features_dict.keys())
+
+        # Remove features not present in dataset
+        for feature in current_features - dataset_features:
+            self.features_dict.pop(feature, None)
+
+        # Add features present in dataset but missing in features_dict
+        for feature in dataset_features - current_features:
             self.features_dict[feature] = feature
 
     def _update_features_dict_with_groups(self, features_groups):

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -170,9 +170,10 @@ class TestSmartExplainer(unittest.TestCase):
         """
         Unit test check features dict 1
         """
-        xpl = SmartExplainer(self.model, features_dict={"Age": "Age (Years Old)"})
+        xpl = SmartExplainer(self.model, features_dict={"Age": "Age (Years Old)", "Place": "Place of Residence"})
         xpl.columns_dict = {0: "Age", 1: "Education", 2: "Sex"}
         xpl.check_features_dict()
+        assert len(xpl.features_dict) == 3
         assert xpl.features_dict["Age"] == "Age (Years Old)"
         assert xpl.features_dict["Education"] == "Education"
 


### PR DESCRIPTION
Fixes: #660

This PR fixes an issue where features defined in `features_dict` but not present in the dataset caused incorrect behavior in the Shapash web app (notably when masking features).

The `check_features_dict` method now fully synchronizes the configuration by:

* Removing features not present in the dataset columns
* Adding missing dataset features to `features_dict`

This ensures consistent feature filtering, prevents UI bugs, and guarantees alignment between the dataset and the web interface.
