### PR TITLE
Add support for Python 3.14 / remove 3.9, 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        #python-version: ["3.11", "3.12", "3.13", "3.14"]
-        python-version: ["3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        #python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.14"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py311-plus]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [--fix]
       - id: ruff-format
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Shapash can use category-encoders object, sklearn ColumnTransformer or simply fe
 
 ## 🛠 Installation
 
-Shapash is intended to work with Python versions 3.9 to 3.12. Installation can be done with pip:
+Shapash is intended to work with Python versions 3.11 to 3.14. Installation can be done with pip:
 
 ```bash
 pip install shapash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,16 @@ authors = [
 ]
 description = "Shapash is a Python library which aims to make machine learning interpretable and understandable by everyone."
 readme = "README.md"
-requires-python = ">=3.11, <=3.14"
+requires-python = ">=3.9, <=3.13"
 license = {text = "Apache Software License 2.0"}
 keywords = ["shapash"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,15 @@ authors = [
 ]
 description = "Shapash is a Python library which aims to make machine learning interpretable and understandable by everyone."
 readme = "README.md"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.11, <=3.14"
 license = {text = "Apache Software License 2.0"}
 keywords = ["shapash"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.11, <3.15"
 license = {text = "Apache Software License 2.0"}
 keywords = ["shapash"]
 classifiers = [
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,15 @@ authors = [
 ]
 description = "Shapash is a Python library which aims to make machine learning interpretable and understandable by everyone."
 readme = "README.md"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.11, <3.15"
 license = {text = "Apache Software License 2.0"}
 keywords = ["shapash"]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "Shapash is a Python library which aims to make machine learning interpretable and understandable by everyone."
 readme = "README.md"
-requires-python = ">=3.9, <=3.13"
+requires-python = ">=3.9, <3.14"
 license = {text = "Apache Software License 2.0"}
 keywords = ["shapash"]
 classifiers = [

--- a/shapash/backend/base_backend.py
+++ b/shapash/backend/base_backend.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,7 @@ class BaseBackend(ABC):
     support_groups = True
     supported_cases = ["classification", "regression"]
 
-    def __init__(self, model: Any, preprocessing: Optional[Any] = None):
+    def __init__(self, model: Any, preprocessing: Any | None = None):
         """Create a backend instance using a given implementation.
 
         Parameters
@@ -63,13 +63,12 @@ class BaseBackend(ABC):
             dict containing local contributions
         """
         raise NotImplementedError(
-            f"`{self.__class__.__name__}` is a subclass of BaseBackend and "
-            f"must implement the `_run_explainer` method"
+            f"`{self.__class__.__name__}` is a subclass of BaseBackend and must implement the `_run_explainer` method"
         )
 
     def get_local_contributions(
-        self, x: pd.DataFrame, explain_data: Any, subset: Optional[list[int]] = None
-    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
+        self, x: pd.DataFrame, explain_data: Any, subset: list[int] | None = None
+    ) -> pd.DataFrame | list[pd.DataFrame]:
         """Get local contributions using the explainer data computed in the `run_explainer`
         method.
 
@@ -109,10 +108,10 @@ class BaseBackend(ABC):
     def get_global_features_importance(
         self,
         contributions: pd.DataFrame,
-        explain_data: Optional[dict] = None,
-        subset: Optional[list[int]] = None,
+        explain_data: dict | None = None,
+        subset: list[int] | None = None,
         norm: int = 1,
-    ) -> Union[pd.Series, list[pd.Series]]:
+    ) -> pd.Series | list[pd.Series]:
         """Get global contributions using the explainer data computed in the `run_explainer`
         method.
 
@@ -141,8 +140,8 @@ class BaseBackend(ABC):
     def format_and_aggregate_local_contributions(
         self,
         x: pd.DataFrame,
-        contributions: Union[pd.DataFrame, np.array, list[pd.DataFrame], list[np.array]],
-    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
+        contributions: pd.DataFrame | np.array | list[pd.DataFrame] | list[np.array],
+    ) -> pd.DataFrame | list[pd.DataFrame]:
         """
         This function allows to format and aggregate contributions in the right format
         (pd.DataFrame or list of pd.DataFrame).
@@ -175,8 +174,8 @@ class BaseBackend(ABC):
         return contributions
 
     def _apply_preprocessing(
-        self, contributions: Union[pd.DataFrame, list[pd.DataFrame]]
-    ) -> Union[pd.DataFrame, list[pd.DataFrame]]:
+        self, contributions: pd.DataFrame | list[pd.DataFrame]
+    ) -> pd.DataFrame | list[pd.DataFrame]:
         """
         Reconstruct contributions for original features, taken into account a preprocessing.
 

--- a/shapash/backend/base_backend.py
+++ b/shapash/backend/base_backend.py
@@ -140,7 +140,7 @@ class BaseBackend(ABC):
     def format_and_aggregate_local_contributions(
         self,
         x: pd.DataFrame,
-        contributions: pd.DataFrame | np.array | list[pd.DataFrame] | list[np.array],
+        contributions: pd.DataFrame | np.ndarray | list[pd.DataFrame] | list[np.ndarray],
     ) -> pd.DataFrame | list[pd.DataFrame]:
         """
         This function allows to format and aggregate contributions in the right format

--- a/shapash/decomposition/contributions.py
+++ b/shapash/decomposition/contributions.py
@@ -117,6 +117,6 @@ def assign_contributions(ranked):
     """
     if len(ranked) != 3:
         raise ValueError(
-            f"Expected lenght : 3, observed lenght : {len(ranked)}," "please check the outputs of rank_contributions."
+            f"Expected lenght : 3, observed lenght : {len(ranked)},please check the outputs of rank_contributions."
         )
     return {"contrib_sorted": ranked[0], "x_sorted": ranked[1], "var_dict": ranked[2]}

--- a/shapash/decomposition/contributions.py
+++ b/shapash/decomposition/contributions.py
@@ -117,6 +117,6 @@ def assign_contributions(ranked):
     """
     if len(ranked) != 3:
         raise ValueError(
-            f"Expected lenght : 3, observed lenght : {len(ranked)},please check the outputs of rank_contributions."
+            f"Expected length : 3, observed length : {len(ranked)}, please check the outputs of rank_contributions."
         )
     return {"contrib_sorted": ranked[0], "x_sorted": ranked[1], "var_dict": ranked[2]}

--- a/shapash/explainer/consistency.py
+++ b/shapash/explainer/consistency.py
@@ -30,7 +30,9 @@ class Consistency:
         desc_df = values.describe(percentiles=np.arange(0.1, 1, 0.1).tolist())
         min_pred, max_init = list(desc_df.loc[["min", "max"]].values)
         desc_pct_df = (desc_df.loc[~desc_df.index.isin(["count", "mean", "std"])] - min_pred) / (max_init - min_pred)
-        color_scale = list(map(list, (zip(desc_pct_df.values.flatten(), self._style_dict["init_contrib_colorscale"], strict=False))))
+        color_scale = list(
+            map(list, (zip(desc_pct_df.values.flatten(), self._style_dict["init_contrib_colorscale"], strict=False)))
+        )
         return color_scale
 
     def compile(self, contributions, x=None, preprocessing=None):
@@ -416,7 +418,9 @@ class Consistency:
             axes = np.array([axes])
         fig.suptitle("Examples of explanations' comparisons for various distances (L2 norm)")
 
-        for n, (i, j, k, l, m, o) in enumerate(zip(method_1, method_2, l2, index, backend_name_1, backend_name_2, strict=False)):
+        for n, (i, j, k, l, m, o) in enumerate(
+            zip(method_1, method_2, l2, index, backend_name_1, backend_name_2, strict=False)
+        ):
             # Only keep top features according to both methods
             idx = np.flip(np.abs(np.concatenate([i, j])).argsort()) % len(i)
             _, first_occurrence_idx = np.unique(idx, return_index=True)
@@ -600,7 +604,8 @@ class Consistency:
                     feature_value if switch else x[c].round(3),
                     weights[0][c].round(2),
                     weights[1][c].round(2),
-                    (weights[0][c] - weights[1][c]).round(2), strict=False,
+                    (weights[0][c] - weights[1][c]).round(2),
+                    strict=False,
                 )
             ]
 

--- a/shapash/explainer/consistency.py
+++ b/shapash/explainer/consistency.py
@@ -30,7 +30,7 @@ class Consistency:
         desc_df = values.describe(percentiles=np.arange(0.1, 1, 0.1).tolist())
         min_pred, max_init = list(desc_df.loc[["min", "max"]].values)
         desc_pct_df = (desc_df.loc[~desc_df.index.isin(["count", "mean", "std"])] - min_pred) / (max_init - min_pred)
-        color_scale = list(map(list, (zip(desc_pct_df.values.flatten(), self._style_dict["init_contrib_colorscale"]))))
+        color_scale = list(map(list, (zip(desc_pct_df.values.flatten(), self._style_dict["init_contrib_colorscale"], strict=False))))
         return color_scale
 
     def compile(self, contributions, x=None, preprocessing=None):
@@ -416,7 +416,7 @@ class Consistency:
             axes = np.array([axes])
         fig.suptitle("Examples of explanations' comparisons for various distances (L2 norm)")
 
-        for n, (i, j, k, l, m, o) in enumerate(zip(method_1, method_2, l2, index, backend_name_1, backend_name_2)):
+        for n, (i, j, k, l, m, o) in enumerate(zip(method_1, method_2, l2, index, backend_name_1, backend_name_2, strict=False)):
             # Only keep top features according to both methods
             idx = np.flip(np.abs(np.concatenate([i, j])).argsort()) % len(i)
             _, first_occurrence_idx = np.unique(idx, return_index=True)
@@ -600,7 +600,7 @@ class Consistency:
                     feature_value if switch else x[c].round(3),
                     weights[0][c].round(2),
                     weights[1][c].round(2),
-                    (weights[0][c] - weights[1][c]).round(2),
+                    (weights[0][c] - weights[1][c]).round(2), strict=False,
                 )
             ]
 

--- a/shapash/explainer/multi_decorator.py
+++ b/shapash/explainer/multi_decorator.py
@@ -75,7 +75,9 @@ class MultiDecorator:
             Raise if there is no argument.
         """
         if not args:
-            raise ValueError(f"{name} is applied without arguments, please check that you have specified contributions.")
+            raise ValueError(
+                f"{name} is applied without arguments, please check that you have specified contributions."
+            )
 
     def check_method(self, method, name):
         """

--- a/shapash/explainer/multi_decorator.py
+++ b/shapash/explainer/multi_decorator.py
@@ -75,7 +75,7 @@ class MultiDecorator:
             Raise if there is no argument.
         """
         if not args:
-            raise ValueError(f"{name} is applied without arguments,please check that you have specified contributions.")
+            raise ValueError(f"{name} is applied without arguments, please check that you have specified contributions.")
 
     def check_method(self, method, name):
         """

--- a/shapash/explainer/multi_decorator.py
+++ b/shapash/explainer/multi_decorator.py
@@ -175,7 +175,7 @@ class MultiDecorator:
         pd.Dataframe
             Combination of all masks.
         """
-        transposed_masks = list(map(list, zip(*masks)))
+        transposed_masks = list(map(list, zip(*masks, strict=False)))
         return self.delegate("combine_masks", transposed_masks)
 
     def compute_masked_contributions(self, s_contrib, masks):
@@ -195,7 +195,7 @@ class MultiDecorator:
         list
             List of masked contributions (pandas.Series).
         """
-        arg_tup = list(zip(s_contrib, masks))
+        arg_tup = list(zip(s_contrib, masks, strict=False))
         return self.delegate("compute_masked_contributions", arg_tup)
 
     def summarize(self, s_contribs, var_dicts, xs_sorted, masks, columns_dict, features_dict):
@@ -222,7 +222,7 @@ class MultiDecorator:
         list of pd.DataFrame
             Result of the summarize step
         """
-        arg_tup = list(zip(s_contribs, var_dicts, xs_sorted, masks))
+        arg_tup = list(zip(s_contribs, var_dicts, xs_sorted, masks, strict=False))
         return self.delegate("summarize", arg_tup, columns_dict, features_dict)
 
     def compute_features_import(self, contributions, norm=1):

--- a/shapash/explainer/multi_decorator.py
+++ b/shapash/explainer/multi_decorator.py
@@ -75,9 +75,7 @@ class MultiDecorator:
             Raise if there is no argument.
         """
         if not args:
-            raise ValueError(
-                f"{name} is applied without arguments," "please check that you have specified contributions."
-            )
+            raise ValueError(f"{name} is applied without arguments,please check that you have specified contributions.")
 
     def check_method(self, method, name):
         """

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -451,7 +451,7 @@ class SmartPlotter:
         if self._explainer._case == "classification":
             label_num, _, label_value = self._explainer.check_label_name(label)
 
-        if not isinstance(col, (str, int)):
+        if not isinstance(col, str | int):
             raise ValueError("parameter col must be string or int.")
         if hasattr(self._explainer, "inv_features_dict"):
             col = self._explainer.inv_features_dict.get(col, col)
@@ -976,7 +976,10 @@ class SmartPlotter:
                     f"Response: <b>{label_value}</b> - "
                     + "Probas: "
                     + " ; ".join(
-                        [str(id) + ": <b>" + str(round(proba, 2)) + "</b>" for proba, id in zip(preds, line_reference, strict=False)]
+                        [
+                            str(id) + ": <b>" + str(round(proba, 2)) + "</b>"
+                            for proba, id in zip(preds, line_reference, strict=False)
+                        ]
                     )
                 )
 
@@ -987,7 +990,10 @@ class SmartPlotter:
             if show_predict:
                 preds = [self._explainer._local_pred(line) for line in line_reference]
                 subtitle = "Predictions: " + " ; ".join(
-                    [str(id) + ": <b>" + str(round(pred, 2)) + "</b>" for id, pred in zip(line_reference, preds, strict=False)]
+                    [
+                        str(id) + ": <b>" + str(round(pred, 2)) + "</b>"
+                        for id, pred in zip(line_reference, preds, strict=False)
+                    ]
                 )
 
         new_contrib = list()
@@ -1121,7 +1127,7 @@ class SmartPlotter:
         >>> xpl.plot.interactions_plot(0, 1)
         """
 
-        if not (isinstance(col1, (str, int)) or isinstance(col2, (str, int))):
+        if not (isinstance(col1, str | int) or isinstance(col2, str | int)):
             raise ValueError("parameters col1 and col2 must be string or int.")
 
         col_id1 = self._explainer.check_features_name([col1])[0]

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -976,7 +976,7 @@ class SmartPlotter:
                     f"Response: <b>{label_value}</b> - "
                     + "Probas: "
                     + " ; ".join(
-                        [str(id) + ": <b>" + str(round(proba, 2)) + "</b>" for proba, id in zip(preds, line_reference)]
+                        [str(id) + ": <b>" + str(round(proba, 2)) + "</b>" for proba, id in zip(preds, line_reference, strict=False)]
                     )
                 )
 
@@ -987,7 +987,7 @@ class SmartPlotter:
             if show_predict:
                 preds = [self._explainer._local_pred(line) for line in line_reference]
                 subtitle = "Predictions: " + " ; ".join(
-                    [str(id) + ": <b>" + str(round(pred, 2)) + "</b>" for id, pred in zip(line_reference, preds)]
+                    [str(id) + ": <b>" + str(round(pred, 2)) + "</b>" for id, pred in zip(line_reference, preds, strict=False)]
                 )
 
         new_contrib = list()
@@ -1005,11 +1005,11 @@ class SmartPlotter:
         preds = [self._explainer.x_init.loc[id] for id in line_reference]
         dict_features = self._explainer.inv_features_dict
 
-        iteration_list = list(zip(new_contrib, feature_values))
+        iteration_list = list(zip(new_contrib, feature_values, strict=False))
         iteration_list.sort(key=lambda x: maximum_difference_sort_value(x), reverse=True)
         iteration_list = iteration_list[:max_features]
         iteration_list = iteration_list[::-1]
-        new_contrib, feature_values = list(zip(*iteration_list))
+        new_contrib, feature_values = list(zip(*iteration_list, strict=False))
 
         fig = plot_line_comparison(
             line_reference,

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -4,7 +4,6 @@ Smart plotter module
 
 import math
 import random
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -1925,7 +1924,7 @@ class SmartPlotter:
     def distribution_plot(
         self,
         col: str,
-        hue: Optional[str] = None,
+        hue: str | None = None,
         width: int = 700,
         height: int = 500,
         nb_cat_max: int = 7,
@@ -2106,7 +2105,7 @@ class SmartPlotter:
 
         if not hasattr(self._explainer, "model"):
             raise AssertionError(
-                "Explainer object was not compiled. Please compile the explainer " "object using .compile(...) method."
+                "Explainer object was not compiled. Please compile the explainer object using .compile(...) method."
             )
 
         if not hasattr(self._explainer, "_case") or self._explainer._case not in {"classification", "regression"}:

--- a/shapash/explainer/smart_state.py
+++ b/shapash/explainer/smart_state.py
@@ -43,7 +43,7 @@ class SmartState:
         pandas.DataFrame
             Local contributions on the original feature space (no encoding).
         """
-        if not isinstance(contributions, (np.ndarray, pd.DataFrame)):
+        if not isinstance(contributions, np.ndarray | pd.DataFrame):
             raise ValueError("Type of contributions must be pd.DataFrame or np.ndarray")
         if isinstance(contributions, np.ndarray):
             return pd.DataFrame(contributions, columns=x_init.columns, index=x_init.index)

--- a/shapash/manipulation/select_lines.py
+++ b/shapash/manipulation/select_lines.py
@@ -49,10 +49,10 @@ def keep_right_contributions(y_pred, contributions, _case, _classes, label_dict,
 
     """
     if _case == "classification":
-        complete_sum = [list(x) for x in list(zip(*[df.values.tolist() for df in contributions]))]
+        complete_sum = [list(x) for x in list(zip(*[df.values.tolist() for df in contributions], strict=False))]
         indexclas = [_classes.index(x) for x in list(flatten(y_pred.values))]
         summary = pd.DataFrame(
-            [summar[ind] for ind, summar in zip(indexclas, complete_sum)],
+            [summar[ind] for ind, summar in zip(indexclas, complete_sum, strict=False)],
             columns=contributions[0].columns,
             index=contributions[0].index,
             dtype=object,
@@ -61,7 +61,7 @@ def keep_right_contributions(y_pred, contributions, _case, _classes, label_dict,
             y_pred = y_pred.map(lambda x: label_dict[x])
         if proba_values is not None:
             y_proba = pd.DataFrame(
-                [proba[ind] for ind, proba in zip(indexclas, proba_values.values)],
+                [proba[ind] for ind, proba in zip(indexclas, proba_values.values, strict=False)],
                 columns=["proba"],
                 index=y_pred.index,
             )

--- a/shapash/manipulation/summarize.py
+++ b/shapash/manipulation/summarize.py
@@ -99,7 +99,7 @@ def summarize(s_contrib, var_dict, x_sorted, mask, columns_dict, features_dict):
     summary = pd.concat([contrib_sum, var_dict_sum, x_sorted_sum], axis=1)
 
     # Ordering columns
-    ordered_columns = list(flatten(zip(var_dict_sum.columns, x_sorted_sum.columns, contrib_sum.columns)))
+    ordered_columns = list(flatten(zip(var_dict_sum.columns, x_sorted_sum.columns, contrib_sum.columns, strict=False)))
     summary = summary[ordered_columns]
     return summary
 

--- a/shapash/plots/plot_bar_chart.py
+++ b/shapash/plots/plot_bar_chart.py
@@ -101,7 +101,7 @@ def plot_bar_chart(
             margin={"l": 150, "r": 20, "t": topmargin, "b": 70},
         )
         bars = []
-        for num, expl in enumerate(zip(var_dict, x_val, contrib)):
+        for num, expl in enumerate(zip(var_dict, x_val, contrib, strict=False)):
             feat_name, x_val_el, contrib_value = expl
             is_grouped = False
             if x_val_el == "":

--- a/shapash/plots/plot_contribution.py
+++ b/shapash/plots/plot_contribution.py
@@ -89,7 +89,9 @@ def plot_scatter(
     feature_values = pd.DataFrame({column_name: feature_values_str})
 
     if pred is not None:
-        hv_text = [f"Id: {x}<br />Predict: {y}" for x, y in zip(feature_values.index, pred.values.flatten(), strict=False)]
+        hv_text = [
+            f"Id: {x}<br />Predict: {y}" for x, y in zip(feature_values.index, pred.values.flatten(), strict=False)
+        ]
     else:
         hv_text = [f"Id: {x}" for x in feature_values.index]
 
@@ -679,7 +681,9 @@ def _prepare_hover_text(feature_values, pred, feature_name):
     hv_text = [
         f"Id: {id_val}{f'<br />Predict: {pred_val}' if pred is not None else ''}"
         for id_val, pred_val in zip(
-            feature_values.index, pred.values.flatten() if pred is not None else [""] * len(feature_values), strict=False
+            feature_values.index,
+            pred.values.flatten() if pred is not None else [""] * len(feature_values),
+            strict=False,
         )
     ]
 

--- a/shapash/plots/plot_contribution.py
+++ b/shapash/plots/plot_contribution.py
@@ -89,7 +89,7 @@ def plot_scatter(
     feature_values = pd.DataFrame({column_name: feature_values_str})
 
     if pred is not None:
-        hv_text = [f"Id: {x}<br />Predict: {y}" for x, y in zip(feature_values.index, pred.values.flatten())]
+        hv_text = [f"Id: {x}<br />Predict: {y}" for x, y in zip(feature_values.index, pred.values.flatten(), strict=False)]
     else:
         hv_text = [f"Id: {x}" for x in feature_values.index]
 
@@ -679,7 +679,7 @@ def _prepare_hover_text(feature_values, pred, feature_name):
     hv_text = [
         f"Id: {id_val}{f'<br />Predict: {pred_val}' if pred is not None else ''}"
         for id_val, pred_val in zip(
-            feature_values.index, pred.values.flatten() if pred is not None else [""] * len(feature_values)
+            feature_values.index, pred.values.flatten() if pred is not None else [""] * len(feature_values), strict=False
         )
     ]
 

--- a/shapash/plots/plot_correlations.py
+++ b/shapash/plots/plot_correlations.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 import pandas as pd
 import scipy.cluster.hierarchy as sch
@@ -14,7 +12,7 @@ from shapash.utils.utils import adjust_title_height, compute_top_correlations_fe
 
 def plot_correlations(
     df,
-    style_dict: Optional[dict] = None,
+    style_dict: dict | None = None,
     palette_name: str = "default",
     features_dict=None,
     optimized=False,
@@ -197,7 +195,7 @@ def plot_correlations(
                     coloraxis="coloraxis",
                     text=[
                         [
-                            f"Feature 1: {features_dict.get(y, y)} <br />" f"Feature 2: {features_dict.get(x, x)}"
+                            f"Feature 1: {features_dict.get(y, y)} <br />Feature 2: {features_dict.get(x, x)}"
                             for x in list_features
                         ]
                         for y in list_features
@@ -219,7 +217,7 @@ def plot_correlations(
                 coloraxis="coloraxis",
                 text=[
                     [
-                        f"Feature 1: {features_dict.get(y, y)} <br />" f"Feature 2: {features_dict.get(x, x)}"
+                        f"Feature 1: {features_dict.get(y, y)} <br />Feature 2: {features_dict.get(x, x)}"
                         for x in list_features
                     ]
                     for y in list_features

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -269,7 +269,8 @@ def _prediction_classification_plot(
             df_correct_predict.index,
             df_correct_predict.proba_values.values.round(3).flatten(),
             df_correct_predict.predict_class.values.flatten(),
-            df_correct_predict.target.values.flatten(), strict=False,
+            df_correct_predict.target.values.flatten(),
+            strict=False,
         )
     ]
     hv_text_wrong_predict = [
@@ -278,7 +279,8 @@ def _prediction_classification_plot(
             df_wrong_predict.index,
             df_wrong_predict.proba_values.values.round(3).flatten(),
             df_wrong_predict.predict_class.values.flatten(),
-            df_wrong_predict.target.values.flatten(), strict=False,
+            df_wrong_predict.target.values.flatten(),
+            strict=False,
         )
     ]
     rng = np.random.default_rng(seed=79)
@@ -444,7 +446,9 @@ def _prediction_regression_plot(y_target, y_pred, prediction_error, list_ind, st
 
         hv_text = [
             f"Id: {x}<br />True Values: {y:,.2f}<br />Predicted Values: {z:,.2f}<br />Prediction Error: {w:,.2f}"
-            for x, y, z, w in zip(y_target.index, y_target_values, y_pred.values.flatten(), prediction_error.flatten(), strict=False)
+            for x, y, z, w in zip(
+                y_target.index, y_target_values, y_pred.values.flatten(), prediction_error.flatten(), strict=False
+            )
         ]
 
         fig.add_scatter(

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -269,7 +269,7 @@ def _prediction_classification_plot(
             df_correct_predict.index,
             df_correct_predict.proba_values.values.round(3).flatten(),
             df_correct_predict.predict_class.values.flatten(),
-            df_correct_predict.target.values.flatten(),
+            df_correct_predict.target.values.flatten(), strict=False,
         )
     ]
     hv_text_wrong_predict = [
@@ -278,7 +278,7 @@ def _prediction_classification_plot(
             df_wrong_predict.index,
             df_wrong_predict.proba_values.values.round(3).flatten(),
             df_wrong_predict.predict_class.values.flatten(),
-            df_wrong_predict.target.values.flatten(),
+            df_wrong_predict.target.values.flatten(), strict=False,
         )
     ]
     rng = np.random.default_rng(seed=79)
@@ -444,7 +444,7 @@ def _prediction_regression_plot(y_target, y_pred, prediction_error, list_ind, st
 
         hv_text = [
             f"Id: {x}<br />True Values: {y:,.2f}<br />Predicted Values: {z:,.2f}<br />Prediction Error: {w:,.2f}"
-            for x, y, z, w in zip(y_target.index, y_target_values, y_pred.values.flatten(), prediction_error.flatten())
+            for x, y, z, w in zip(y_target.index, y_target_values, y_pred.values.flatten(), prediction_error.flatten(), strict=False)
         ]
 
         fig.add_scatter(
@@ -548,7 +548,7 @@ def plot_confusion_matrix(
 
     init_colorscale = style_dict["init_confusion_matrix_colorscale"]
     linspace = np.linspace(0, 1, len(init_colorscale))
-    col_scale = [(value, color) for value, color in zip(linspace, init_colorscale)]
+    col_scale = [(value, color) for value, color in zip(linspace, init_colorscale, strict=False)]
 
     # Convert the DataFrame to a NumPy array
     x_labels = list(df_cm.columns)
@@ -565,8 +565,8 @@ def plot_confusion_matrix(
     y_numeric = all(str(label).isdigit() for label in y_labels)
 
     hv_text = [
-        [f"Actual: {y}<br>Predicted: {x}<br>Count: {value}" for x, value in zip(x_labels, row)]
-        for y, row in zip(y_labels, z)
+        [f"Actual: {y}<br>Predicted: {x}<br>Count: {value}" for x, value in zip(x_labels, row, strict=False)]
+        for y, row in zip(y_labels, z, strict=False)
     ]
 
     if not x_numeric:

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import numpy as np
 import pandas as pd
 from plotly import graph_objs as go
@@ -497,9 +495,9 @@ def _prediction_regression_plot(y_target, y_pred, prediction_error, list_ind, st
 
 
 def plot_confusion_matrix(
-    y_true: Union[np.ndarray, list],
-    y_pred: Union[np.ndarray, list],
-    colors_dict: Optional[dict] = None,
+    y_true: np.ndarray | list,
+    y_pred: np.ndarray | list,
+    colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
     palette_name: str = "default",

--- a/shapash/plots/plot_feature_importance.py
+++ b/shapash/plots/plot_feature_importance.py
@@ -362,7 +362,7 @@ def _plot_local_features_import(
     dict_xaxis = style_dict["dict_xaxis"] | {"text": "Mean absolute Contribution"}
     dict_yaxis = style_dict["dict_yaxis"] | {"text": None}
     dict_style_bar = {}
-    for type_feat, i in zip(["global", "semi-local", "local"], [1, 3, 4]):
+    for type_feat, i in zip(["global", "semi-local", "local"], [1, 3, 4], strict=False):
         dict_style_bar[type_feat] = style_dict["dict_featimp_colors"][i]
 
     # Change bar color for groups of features

--- a/shapash/plots/plot_line_comparison.py
+++ b/shapash/plots/plot_line_comparison.py
@@ -89,7 +89,7 @@ def plot_line_comparison(
         margin={"l": 150, "r": 20, "t": topmargin, "b": 70},
     )
 
-    iteration_list = list(zip(contributions, feature_values))
+    iteration_list = list(zip(contributions, feature_values, strict=False))
     len_dic_color = len(style_dict["dict_compare_colors"])
     lines = list()
 

--- a/shapash/plots/plot_stability.py
+++ b/shapash/plots/plot_stability.py
@@ -306,7 +306,7 @@ def plot_amplitude_vs_stability(
     yaxis_title = "Importance<span style='font-size: 12px;'><br />(Average contributions)</span>"
     hv_text = [
         f"<b>Feature: {col}</b><br />Importance: {y}<br />Variability: {x}"
-        for col, x, y in zip(column_names, mean_variability, mean_amplitude)
+        for col, x, y in zip(column_names, mean_variability, mean_amplitude, strict=False)
     ]
     hovertemplate = "%{hovertext}" + "<extra></extra>"
 

--- a/shapash/plots/plot_univariate.py
+++ b/shapash/plots/plot_univariate.py
@@ -211,7 +211,7 @@ def plot_continuous_distribution(
             # Generate hovertext
             hv_text = [
                 f"{hue}: {level}<br>{col}: {format(x, f'.{max(0, compute_digit_number(x, 3))}f')}<br>Density: {y:.4f}"
-                for x, y in zip(x_values, y_values)
+                for x, y in zip(x_values, y_values, strict=False)
             ]
 
             color = style_dict.get(level, random_color())
@@ -242,7 +242,7 @@ def plot_continuous_distribution(
         # Generate hovertext
         hv_text = [
             f"{col}: {format(x, f'.{max(0, compute_digit_number(x, 3))}f')}<br>Density: {y:.4f}"
-            for x, y in zip(x_values, y_values)
+            for x, y in zip(x_values, y_values, strict=False)
         ]
 
         color = style_dict.get(col, random_color())

--- a/shapash/plots/plot_univariate.py
+++ b/shapash/plots/plot_univariate.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -15,8 +14,8 @@ from shapash.utils.utils import adjust_title_height, compute_digit_number
 def plot_distribution(
     df_all: pd.DataFrame,
     col: str,
-    hue: Optional[str] = None,
-    colors_dict: Optional[dict] = None,
+    hue: str | None = None,
+    colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
     palette_name: str = "default",
@@ -119,8 +118,8 @@ def plot_distribution(
 def plot_continuous_distribution(
     df_all: pd.DataFrame,
     col: str,
-    hue: Optional[str] = None,
-    colors_dict: Optional[dict] = None,
+    hue: str | None = None,
+    colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
     palette_name: str = "default",
@@ -211,9 +210,7 @@ def plot_continuous_distribution(
 
             # Generate hovertext
             hv_text = [
-                f"{hue}: {level}<br>"
-                f"{col}: {format(x, f'.{max(0, compute_digit_number(x, 3))}f')}<br>"
-                f"Density: {y:.4f}"
+                f"{hue}: {level}<br>{col}: {format(x, f'.{max(0, compute_digit_number(x, 3))}f')}<br>Density: {y:.4f}"
                 for x, y in zip(x_values, y_values)
             ]
 
@@ -244,7 +241,7 @@ def plot_continuous_distribution(
 
         # Generate hovertext
         hv_text = [
-            f"{col}: {format(x, f'.{max(0, compute_digit_number(x, 3))}f')}<br>" f"Density: {y:.4f}"
+            f"{col}: {format(x, f'.{max(0, compute_digit_number(x, 3))}f')}<br>Density: {y:.4f}"
             for x, y in zip(x_values, y_values)
         ]
 
@@ -296,10 +293,10 @@ def plot_continuous_distribution(
 def plot_categorical_distribution(
     df_all: pd.DataFrame,
     col: str,
-    hue: Optional[str] = None,
+    hue: str | None = None,
     nb_cat_max: int = 7,
     nb_hue_max: int = 7,
-    colors_dict: Optional[dict] = None,
+    colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
     palette_name: str = "default",
@@ -466,7 +463,7 @@ def plot_categorical_distribution(
     return fig
 
 
-def _merge_small_categories(df_cat: pd.DataFrame, col: str, hue: Optional[str], nb_cat_max: int) -> pd.DataFrame:
+def _merge_small_categories(df_cat: pd.DataFrame, col: str, hue: str | None, nb_cat_max: int) -> pd.DataFrame:
     """
     Merges smaller categories into a single "Other" category.
 

--- a/shapash/report/base_report.ipynb
+++ b/shapash/report/base_report.ipynb
@@ -22,8 +22,8 @@
    },
    "outputs": [],
    "source": [
-    "dir_path = ''\n",
-    "project_info_file = ''\n",
+    "dir_path = \"\"\n",
+    "project_info_file = \"\"\n",
     "config = dict()"
    ]
   },
@@ -36,24 +36,20 @@
    "source": [
     "import os\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
     "from shapash import SmartExplainer\n",
     "from shapash.report.project_report import ProjectReport\n",
     "from shapash.report.common import load_saved_df\n",
     "\n",
-    "xpl = SmartExplainer.load(os.path.join(dir_path, 'smart_explainer.pickle'))\n",
+    "xpl = SmartExplainer.load(os.path.join(dir_path, \"smart_explainer.pickle\"))\n",
     "\n",
-    "x_train = load_saved_df(os.path.join(dir_path, 'x_train.csv'))\n",
-    "y_train = load_saved_df(os.path.join(dir_path, 'y_train.csv'))\n",
-    "y_test = load_saved_df(os.path.join(dir_path, 'y_test.csv'))\n",
+    "x_train = load_saved_df(os.path.join(dir_path, \"x_train.csv\"))\n",
+    "y_train = load_saved_df(os.path.join(dir_path, \"y_train.csv\"))\n",
+    "y_test = load_saved_df(os.path.join(dir_path, \"y_test.csv\"))\n",
     "\n",
     "report = ProjectReport(\n",
-    "    explainer=xpl, \n",
-    "    project_info_file=project_info_file, \n",
-    "    x_train=x_train, \n",
-    "    y_train=y_train,\n",
-    "    y_test=y_test, \n",
-    "    config=config\n",
+    "    explainer=xpl, project_info_file=project_info_file, x_train=x_train, y_train=y_train, y_test=y_test, config=config\n",
     ")"
    ]
   },

--- a/shapash/report/common.py
+++ b/shapash/report/common.py
@@ -1,7 +1,6 @@
 import os
 from enum import Enum
 from numbers import Number
-from typing import Optional, Union
 
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype, is_string_dtype
@@ -72,7 +71,7 @@ def numeric_is_continuous(s: pd.Series, threshold: int = 15) -> bool:
     return n_unique > threshold
 
 
-def compute_col_types(df_all: Optional[pd.DataFrame]) -> Optional[dict]:
+def compute_col_types(df_all: pd.DataFrame | None) -> dict | None:
     """
     Computes the type of each column and stores the result in a dict.
 
@@ -135,7 +134,7 @@ def get_callable(path: str):
         raise ValueError(f"Invalid type ({type(obj)}) found for {path}")
 
 
-def load_saved_df(path: str) -> Union[pd.DataFrame, None]:
+def load_saved_df(path: str) -> pd.DataFrame | None:
     """
     Loads a pandas DataFrame that was saved using pd.to_csv method.
 

--- a/shapash/report/data_analysis.py
+++ b/shapash/report/data_analysis.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 import pandas as pd
 
 from shapash.report.common import VarType, display_value, replace_dict_values
 from shapash.webapp.utils.utils import round_to_k
 
 
-def perform_global_dataframe_analysis(df: Optional[pd.DataFrame]) -> dict:
+def perform_global_dataframe_analysis(df: pd.DataFrame | None) -> dict:
     """
     Returns a python dict containing global information about a pandas DataFrame :
     Number of features, Number of observations, missing values...
@@ -42,7 +40,7 @@ def perform_global_dataframe_analysis(df: Optional[pd.DataFrame]) -> dict:
     return global_d
 
 
-def perform_univariate_dataframe_analysis(df: Optional[pd.DataFrame], col_types: dict) -> dict:
+def perform_univariate_dataframe_analysis(df: pd.DataFrame | None, col_types: dict) -> dict:
     """
     Returns a python dict containing information about each column of a pandas DataFrame.
     The computed information depends on the type of the column.

--- a/shapash/report/generation.py
+++ b/shapash/report/generation.py
@@ -3,7 +3,6 @@ Report generation helper module.
 """
 
 import os
-from typing import Optional, Union
 
 import pandas as pd
 import papermill as pm
@@ -16,12 +15,12 @@ def execute_report(
     working_dir: str,
     explainer: object,
     project_info_file: str,
-    x_train: Optional[pd.DataFrame] = None,
-    y_train: Optional[pd.DataFrame] = None,
-    y_test: Optional[Union[pd.Series, pd.DataFrame]] = None,
-    config: Optional[dict] = None,
-    notebook_path: Optional[str] = None,
-    kernel_name: Optional[str] = None,
+    x_train: pd.DataFrame | None = None,
+    y_train: pd.DataFrame | None = None,
+    y_test: pd.Series | pd.DataFrame | None = None,
+    config: dict | None = None,
+    notebook_path: str | None = None,
+    kernel_name: str | None = None,
 ):
     """
     Executes the base_report.ipynb notebook and saves the results in working_dir.

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -566,7 +566,7 @@ class ProjectReport:
                 if isinstance(res, Number):
                     res = display_value(round_to_k(res, 3))
                     print_md(f"**{metric['name']} :** {res}")
-                elif isinstance(res, (list, tuple, np.ndarray)):
+                elif isinstance(res, list | tuple | np.ndarray):
                     print_md(f"**{metric['name']} :**")
                     print_html(pd.DataFrame(res).to_html(classes="greyGridTable"))
                 elif isinstance(res, str):

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -4,7 +4,6 @@ import os
 import sys
 from datetime import date
 from numbers import Number
-from typing import Optional, Union
 
 import jinja2
 import numpy as np
@@ -70,10 +69,10 @@ class ProjectReport:
         self,
         explainer: SmartExplainer,
         project_info_file: str,
-        x_train: Optional[pd.DataFrame] = None,
-        y_train: Optional[pd.DataFrame] = None,
-        y_test: Optional[pd.DataFrame] = None,
-        config: Optional[dict] = None,
+        x_train: pd.DataFrame | None = None,
+        y_train: pd.DataFrame | None = None,
+        y_test: pd.DataFrame | None = None,
+        config: dict | None = None,
     ):
         self.explainer = explainer
         self.metadata = load_yml(path=project_info_file)
@@ -136,8 +135,8 @@ class ProjectReport:
 
     @staticmethod
     def _get_values_and_name(
-        y: Optional[Union[pd.DataFrame, pd.Series, list]], default_name: str
-    ) -> Union[tuple[list, str], tuple[None, None]]:
+        y: pd.DataFrame | pd.Series | list | None, default_name: str
+    ) -> tuple[list, str] | tuple[None, None]:
         """
         Extracts vales and column name from a Pandas Series, DataFrame, or assign a default
         name if y is a list of values.
@@ -173,7 +172,7 @@ class ProjectReport:
         return values, name
 
     @staticmethod
-    def _create_train_test_df(test: Optional[pd.DataFrame], train: Optional[pd.DataFrame]) -> Union[pd.DataFrame, None]:
+    def _create_train_test_df(test: pd.DataFrame | None, train: pd.DataFrame | None) -> pd.DataFrame | None:
         """
         Creates a DataFrame that contains train and test dataset with the column 'data_train_test'
         allowing to distinguish the values.
@@ -400,7 +399,7 @@ class ProjectReport:
     def _stats_to_table(
         test_stats: dict,
         names: list,
-        train_stats: Optional[dict] = None,
+        train_stats: dict | None = None,
     ) -> pd.DataFrame:
         if train_stats is not None:
             return pd.DataFrame({names[1]: pd.Series(train_stats), names[0]: pd.Series(test_stats)})

--- a/shapash/utils/check.py
+++ b/shapash/utils/check.py
@@ -127,7 +127,7 @@ def check_y(x=None, y=None, y_name="y_target"):
         Name of y ("y_target" or "y_pred")
     """
     if y is not None:
-        if not isinstance(y, (pd.DataFrame, pd.Series)):
+        if not isinstance(y, pd.DataFrame | pd.Series):
             raise ValueError(f"{y_name} must be a one column pd.Dataframe or pd.Series.")
         if not y.index.equals(x.index):
             raise ValueError(f"x and {y_name} should have the same index.")
@@ -140,7 +140,7 @@ def check_y(x=None, y=None, y_name="y_target"):
             if y.dtype not in [float, int, np.int32, np.float32, np.int64, np.float64]:
                 raise ValueError(f"{y_name} must contain int or float only")
             y = y.to_frame()
-            if isinstance(y.columns[0], (int, float)):
+            if isinstance(y.columns[0], int | float):
                 y.columns = [y_name]
     return y
 
@@ -159,7 +159,7 @@ def check_contribution_object(case, classes, contributions):
         List of labels if the model used is for classification problem, None otherwise.
     contributions : pandas.DataFrame, np.ndarray or list
     """
-    if (case == "regression") and (not isinstance(contributions, (np.ndarray, pd.DataFrame))):
+    if (case == "regression") and (not isinstance(contributions, np.ndarray | pd.DataFrame)):
         raise ValueError(
             """
             Type of contributions parameter specified is not compatible with

--- a/shapash/utils/clustering.py
+++ b/shapash/utils/clustering.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -20,7 +19,7 @@ logger = logging.getLogger(__name__)
 def compute_tsne_projection(
     values_to_project: pd.DataFrame,
     random_state: int = 79,
-    perplexity: Optional[int] = None,
+    perplexity: int | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Compute a 2D TSNE projection of high-dimensional data.
@@ -58,9 +57,9 @@ def compute_tsne_projection(
 
 
 def build_tsne_title(
-    title: Optional[str],
-    subtitle: Optional[str],
-    addnote: Optional[str],
+    title: str | None,
+    subtitle: str | None,
+    addnote: str | None,
     *,
     style_dict: dict,
     height: int,

--- a/shapash/utils/transform.py
+++ b/shapash/utils/transform.py
@@ -300,7 +300,7 @@ def adapt_contributions(case, contributions):
     if isinstance(contributions, np.ndarray) and contributions.ndim == 3:
         contributions = [contributions[:, :, i] for i in range(contributions.shape[-1])]
     if (isinstance(contributions, pd.DataFrame) and case == "classification") or (
-        isinstance(contributions, (np.ndarray, list)) and case == "classification" and np.array(contributions).ndim == 2
+        isinstance(contributions, np.ndarray | list) and case == "classification" and np.array(contributions).ndim == 2
     ):
         return [contributions * -1, contributions]
     else:

--- a/shapash/utils/utils.py
+++ b/shapash/utils/utils.py
@@ -161,7 +161,7 @@ def add_line_break(value, nbchar, maxlen=150):
         else:
             last_char = "..."
 
-        new_string = "".join(sum(zip(input_word, final_sep + [""]), ())[:-1]) + last_char
+        new_string = "".join(sum(zip(input_word, final_sep + [""], strict=False), ())[:-1]) + last_char
         return new_string
     else:
         return value
@@ -457,7 +457,7 @@ def tuning_colorscale(
     if nunique in [2, n_colors]:
         cmin, cmax = min(unique_vals), max(unique_vals)
         positions = np.linspace(0, 1, n_colors)
-        color_scale = [(float(pos), col) for pos, col in zip(positions, init_colorscale)]
+        color_scale = [(float(pos), col) for pos, col in zip(positions, init_colorscale, strict=False)]
         return color_scale, cmin, cmax
 
     # Case 3: Filter based on quantile range if requested
@@ -491,7 +491,7 @@ def tuning_colorscale(
         else:
             positions = (quantile_values - min_q) / (max_q - min_q)
 
-    color_scale = [(float(pos), col) for pos, col in zip(positions, init_colorscale)]
+    color_scale = [(float(pos), col) for pos, col in zip(positions, init_colorscale, strict=False)]
     return color_scale, cmin, cmax
 
 

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -2074,7 +2074,7 @@ class SmartApp:
                     end_date,
                 )
                 filtered_subset_info = (
-                    f"Subset length: {len(df)} ({int(round(100*len(df)/self.explainer.x_init.shape[0]))}%)"
+                    f"Subset length: {len(df)} ({int(round(100 * len(df) / self.explainer.x_init.shape[0]))}%)"
                 )
                 if len(df) == 0:
                     filtered_subset_color = "danger"

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -155,9 +155,14 @@ class SmartApp:
         """
         if hasattr(self.explainer, "y_pred"):
             self.dataframe = self.explainer.x_init.copy()
-            if isinstance(self.explainer.y_pred, pd.Series | pd.DataFrame):
-                self.predict_col = self.explainer.y_pred.columns.to_list()[0]
-                self.dataframe = self.dataframe.join(self.explainer.y_pred)
+            if isinstance(self.explainer.y_pred, pd.Series):
+                y_pred = self.explainer.y_pred.to_frame()
+                self.predict_col = y_pred.columns.to_list()[0]
+                self.dataframe = self.dataframe.join(y_pred)
+            elif isinstance(self.explainer.y_pred, pd.DataFrame):
+                y_pred = self.explainer.y_pred
+                self.predict_col = y_pred.columns.to_list()[0]
+                self.dataframe = self.dataframe.join(y_pred)
             elif isinstance(self.explainer.y_pred, list):
                 self.dataframe = self.dataframe.join(
                     pd.DataFrame(

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -155,7 +155,7 @@ class SmartApp:
         """
         if hasattr(self.explainer, "y_pred"):
             self.dataframe = self.explainer.x_init.copy()
-            if isinstance(self.explainer.y_pred, (pd.Series, pd.DataFrame)):
+            if isinstance(self.explainer.y_pred, pd.Series | pd.DataFrame):
                 self.predict_col = self.explainer.y_pred.columns.to_list()[0]
                 self.dataframe = self.dataframe.join(self.explainer.y_pred)
             elif isinstance(self.explainer.y_pred, list):

--- a/shapash/webapp/utils/callbacks.py
+++ b/shapash/webapp/utils/callbacks.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from shapash.explainer.smart_explainer import SmartExplainer
@@ -228,7 +228,7 @@ def get_feature_from_clicked_data(click_data: dict) -> str:
     return selected_feature
 
 
-def get_feature_from_features_groups(selected_feature: Optional[str], features_groups: dict) -> Optional[str]:
+def get_feature_from_features_groups(selected_feature: str | None, features_groups: dict) -> str | None:
     """Get the group feature name of the selected feature.
 
     Parameters
@@ -251,7 +251,7 @@ def get_feature_from_features_groups(selected_feature: Optional[str], features_g
     return selected_feature
 
 
-def get_indexes_from_datatable(data: list, list_index: Optional[list] = None) -> Optional[list]:
+def get_indexes_from_datatable(data: list, list_index: list | None = None) -> list | None:
     """Get the indexes of the data. If list_index is given and is the same length than
     the indexes, there is no subset selected.
 
@@ -313,7 +313,7 @@ def get_figure_zoom(click_zoom: int) -> bool:
     return zoom_active
 
 
-def get_feature_contributions_sign_to_show(positive: list, negative: list) -> Optional[bool]:
+def get_feature_contributions_sign_to_show(positive: list, negative: list) -> bool | None:
     """Get the feature contributions sign to show on plot.
 
     Parameters
@@ -561,7 +561,7 @@ def get_feature_filter_options(dataframe: pd.DataFrame, features_dict: dict, spe
     return options
 
 
-def create_dropdown_feature_filter(n_clicks_add: Optional[int], options: list) -> html.Div:
+def create_dropdown_feature_filter(n_clicks_add: int | None, options: list) -> html.Div:
     """Create a new dropdown for the filter feature selection.
 
     Parameters
@@ -698,7 +698,7 @@ def create_filter_modalities_selection(value: str, id: dict, round_dataframe: pd
     return new_element
 
 
-def handle_page_navigation(triggered_input: str, page: Union[int, str], selected_feature: str) -> tuple[int, str]:
+def handle_page_navigation(triggered_input: str, page: int | str, selected_feature: str) -> tuple[int, str]:
     """
     Handle the navigation between different pages based on user input.
 

--- a/shapash/webapp/webapp_launch.py
+++ b/shapash/webapp/webapp_launch.py
@@ -238,11 +238,11 @@ y_target = pd.DataFrame(data=y, columns=y.columns.to_list(), index=titanic_enc.i
 # Tableau récapitulatif
 # -----------------------------
 if CASE == 1:
-    print(f"Mean Fare: {y_target.iloc[:,0].mean():.2f}")
+    print(f"Mean Fare: {y_target.iloc[:, 0].mean():.2f}")
 elif CASE == 2:
-    print(f"Survival Rate: {y_target.iloc[:,0].mean():.2f}")
+    print(f"Survival Rate: {y_target.iloc[:, 0].mean():.2f}")
 else:
-    print(f"Class distribution: {y_target.iloc[:,0].value_counts(normalize=True)}")
+    print(f"Class distribution: {y_target.iloc[:, 0].value_counts(normalize=True)}")
 
 print(df_metrics)
 

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -635,13 +635,13 @@ class TestSmartExplainer(unittest.TestCase):
         temp, xpl = init_sme_to_pickle_test()
 
         current = Path(path.abspath(__file__)).parent.parent.parent
-        if str(sys.version)[0:4] == "3.11":
+        if sys.version_info[:2] == (3, 11):
             pkl_file = path.join(current, "data/xpl_to_load_311.pkl")
-        elif str(sys.version)[0:4] == "3.12":
+        elif sys.version_info[:2] == (3, 12):
             pkl_file = path.join(current, "data/xpl_to_load_312.pkl")
-        elif str(sys.version)[0:4] == "3.13":
+        elif sys.version_info[:2] == (3, 13):
             pkl_file = path.join(current, "data/xpl_to_load_313.pkl")
-        elif str(sys.version)[0:4] == "3.14":
+        elif sys.version_info[:2] == (3, 14):
             pkl_file = path.join(current, "data/xpl_to_load_314.pkl")
         else:
             raise NotImplementedError

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -635,16 +635,14 @@ class TestSmartExplainer(unittest.TestCase):
         temp, xpl = init_sme_to_pickle_test()
 
         current = Path(path.abspath(__file__)).parent.parent.parent
-        if str(sys.version)[0:3] == "3.9":
-            pkl_file = path.join(current, "data/xpl_to_load_39.pkl")
-        elif str(sys.version)[0:4] == "3.10":
-            pkl_file = path.join(current, "data/xpl_to_load_310.pkl")
-        elif str(sys.version)[0:4] == "3.11":
+        if str(sys.version)[0:4] == "3.11":
             pkl_file = path.join(current, "data/xpl_to_load_311.pkl")
         elif str(sys.version)[0:4] == "3.12":
             pkl_file = path.join(current, "data/xpl_to_load_312.pkl")
         elif str(sys.version)[0:4] == "3.13":
             pkl_file = path.join(current, "data/xpl_to_load_313.pkl")
+        elif str(sys.version)[0:4] == "3.14":
+            pkl_file = path.join(current, "data/xpl_to_load_314.pkl")
         else:
             raise NotImplementedError
 

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -658,7 +658,7 @@ class TestSmartPlotter(unittest.TestCase):
         bars = []
         for num, elem in enumerate(var_dict):
             bars.append(
-                go.Bar(x=[contributions[num]], y=["<b>{} :</b><br />{}".format(elem, x_val[num])], orientation="h")
+                go.Bar(x=[contributions[num]], y=[f"<b>{elem} :</b><br />{x_val[num]}"], orientation="h")
             )
         expected_output_fig = go.Figure(data=bars, layout=go.Layout(yaxis=dict(type="category")))
         self.smart_explainer._case = "regression"

--- a/tests/unit_tests/utils/test_load_smartpredictor.py
+++ b/tests/unit_tests/utils/test_load_smartpredictor.py
@@ -28,16 +28,14 @@ class Test_load_smartpredictor(unittest.TestCase):
         predictor = xpl.to_smartpredictor()
 
         current = Path(path.abspath(__file__)).parent.parent.parent
-        if str(sys.version)[0:4] == "3.10":
-            pkl_file = path.join(current, "data/predictor_to_load_310.pkl")
-        elif str(sys.version)[0:3] == "3.9":
-            pkl_file = path.join(current, "data/predictor_to_load_39.pkl")
-        elif str(sys.version)[0:4] == "3.11":
+        if str(sys.version)[0:4] == "3.11":
             pkl_file = path.join(current, "data/predictor_to_load_311.pkl")
         elif str(sys.version)[0:4] == "3.12":
             pkl_file = path.join(current, "data/predictor_to_load_312.pkl")
         elif str(sys.version)[0:4] == "3.13":
             pkl_file = path.join(current, "data/predictor_to_load_313.pkl")
+        elif str(sys.version)[0:4] == "3.14":
+            pkl_file = path.join(current, "data/predictor_to_load_314.pkl")
         else:
             raise NotImplementedError
 

--- a/tests/unit_tests/utils/test_load_smartpredictor.py
+++ b/tests/unit_tests/utils/test_load_smartpredictor.py
@@ -28,13 +28,13 @@ class Test_load_smartpredictor(unittest.TestCase):
         predictor = xpl.to_smartpredictor()
 
         current = Path(path.abspath(__file__)).parent.parent.parent
-        if str(sys.version)[0:4] == "3.11":
+        if sys.version_info[:2] == (3, 11):
             pkl_file = path.join(current, "data/predictor_to_load_311.pkl")
-        elif str(sys.version)[0:4] == "3.12":
+        elif sys.version_info[:2] == (3, 12):
             pkl_file = path.join(current, "data/predictor_to_load_312.pkl")
-        elif str(sys.version)[0:4] == "3.13":
+        elif sys.version_info[:2] == (3, 13):
             pkl_file = path.join(current, "data/predictor_to_load_313.pkl")
-        elif str(sys.version)[0:4] == "3.14":
+        elif sys.version_info[:2] == (3, 14):
             pkl_file = path.join(current, "data/predictor_to_load_314.pkl")
         else:
             raise NotImplementedError


### PR DESCRIPTION
## Description
Fix issue #653 
This PR changes the previously supported versions of python by shapash from (3.9, 3.10, 3.11, 3.12, 3.13) to (3.11, 3.12, 3.13, 3.14)

## Main changes
### Formating
Adopting new formating conventions such as:
Changing optional formating
```python
-        isinstance(contributions, (np.ndarray, list)) and case == "classification" and np.array(contributions).ndim == 2
+        isinstance(contributions, np.ndarray | list) and case == "classification" and np.array(contributions).ndim == 2
```
```python
-    title: Optional[str],
-    subtitle: Optional[str],
-    addnote: Optional[str],
+    title: str | None,
+    subtitle: str | None,
+    addnote: str | None,
```
And new zip argument that was added to indicate that there may be a silent error in it (it was "False" by default)
```python
-    for type_feat, i in zip(["global", "semi-local", "local"], [1, 3, 4]):
+    for type_feat, i in zip(["global", "semi-local", "local"], [1, 3, 4], strict=False):
```

### Changing versions
Files:
- **pyproject.toml**
- **main.yml**
- **test_load_smartpredictor.py**
- **test_smart_explainer.py**
