### PR TITLE
fix: filter None values from report config to prevent ValueError

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1780,14 +1780,18 @@ class SmartExplainer:
                 x_train=x_train,
                 y_train=y_train,
                 y_test=y_test,
-                config=dict(
-                    title_story=title_story,
-                    title_description=title_description,
-                    metrics=metrics,
-                    max_points=max_points,
-                    display_interaction_plot=display_interaction_plot,
-                    nb_top_interactions=nb_top_interactions,
-                ),
+                config={
+                    k: v
+                    for k, v in dict(
+                        title_story=title_story,
+                        title_description=title_description,
+                        metrics=metrics,
+                        max_points=max_points,
+                        display_interaction_plot=display_interaction_plot,
+                        nb_top_interactions=nb_top_interactions,
+                    ).items()
+                    if v is not None
+                },
                 notebook_path=notebook_path,
                 kernel_name=kernel_name,
             )

--- a/tests/integration_tests/test_report_generation.py
+++ b/tests/integration_tests/test_report_generation.py
@@ -126,6 +126,18 @@ class TestGeneration(unittest.TestCase):
 
         shutil.rmtree(tmp_dir_path)
 
+    def test_generate_report_1(self):
+        tmp_dir_path = tempfile.mkdtemp()
+        outfile = os.path.join(tmp_dir_path, "report.html")
+
+        self.xpl.generate_report(
+            output_file=outfile,
+            project_info_file=os.path.join(current_path, "../data/metadata.yaml"),
+        )
+        assert os.path.exists(outfile)
+
+        shutil.rmtree(tmp_dir_path)
+
     def test_export_and_save_report_1(self):
         tmp_dir_path = tempfile.mkdtemp()
 


### PR DESCRIPTION
## Summary

- `generate_report()` crashes with `ValueError: The metrics parameter expects a list of dict` when called without explicitly passing `metrics` (i.e. using the default `None`)
- Root cause: `metrics=None` is packed into the config dict, and `ProjectReport.__init__` checks `"metrics" in self.config.keys()` (True, since the key exists) but then fails on `isinstance(None, list)`
- Fix: filter `None` values out of the config dict before passing it to `execute_report()`

Fixes #691

## Reproduction

```python
from shapash import SmartExplainer
# ... train any model, compile explainer ...

# This crashes on 2.8.1 without the fix:
xpl.generate_report(
    output_file="report.html",
    project_info_file="project_info.yml",
)
```

## Test plan

- [x] Verified reprex crashes on shapash 2.8.1
- [x] Verified reprex passes with this fix applied
- [x] Verified `generate_report()` with explicit `metrics=[...]` still works (existing behavior unchanged)

This pull request was AI-assisted by Claude (but proofread by Marshall)