### PR TITLE
Bug remove pandas 3.0 constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "nbformat>5.8.0",
     "numba>=0.60.0",
     "numpy>=2.0.0,<2.4.0",
-    "pandas>=2.2.2,<3.0.0",
+    "pandas>=2.2.2",
     "plotly>=5.0.0,<6.0.0",
     "scikit-learn>=1.4.2,<1.6.0",
     "scipy>=1.13.0",

--- a/shapash/backend/lime_backend.py
+++ b/shapash/backend/lime_backend.py
@@ -45,7 +45,9 @@ class LimeBackend(BaseBackend):
                 num_classes = len(self._classes)
 
                 if num_classes <= 2:
-                    exp = explainer.explain_instance(x.loc[i], self.model.predict_proba, num_features=x.shape[1])
+                    exp = explainer.explain_instance(
+                        x.loc[i].to_numpy(), self.model.predict_proba, num_features=x.shape[1]
+                    )
                     lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
 
                 elif num_classes > 2:
@@ -66,7 +68,7 @@ class LimeBackend(BaseBackend):
                     return contribution
 
             else:
-                exp = explainer.explain_instance(x.loc[i], self.model.predict, num_features=x.shape[1])
+                exp = explainer.explain_instance(x.loc[i].to_numpy(), self.model.predict, num_features=x.shape[1])
                 lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
 
         contributions = pd.DataFrame(lime_contrib, index=x.index)

--- a/shapash/utils/transform.py
+++ b/shapash/utils/transform.py
@@ -75,7 +75,26 @@ def inverse_transform(x_init, preprocessing=None):
                 x_inverse = inv_transform_ct(x_inverse, encoding)
             else:
                 x_inverse = inv_transform_ce(x_inverse, encoding)
-        return x_inverse
+        return _normalize_str_dtypes(x_inverse)
+
+
+def _normalize_str_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Cast any StringDtype variant to object dtype for compatibility across pandas 2.x and 3.x.
+    See: https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#migration-guide
+    """
+    result = df.copy()
+
+    # Normalize the columns Index itself
+    if isinstance(result.columns.dtype, pd.StringDtype):
+        result.columns = result.columns.astype(object)
+
+    # Normalize column values
+    for col in result.columns:
+        if isinstance(result[col].dtype, pd.StringDtype):
+            result[col] = result[col].astype(object)
+
+    return result
 
 
 def apply_preprocessing(x_init, model, preprocessing=None):

--- a/tests/integration_tests/test_integration_inverse_tranform.py
+++ b/tests/integration_tests/test_integration_inverse_tranform.py
@@ -7,7 +7,7 @@ from os.path import abspath, dirname, join
 import category_encoders as ce
 import pandas as pd
 
-from shapash.utils.transform import inverse_transform
+from shapash.utils.transform import inverse_transform, _normalize_str_dtypes
 
 
 class TestInverseTranform(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestInverseTranform(unittest.TestCase):
         preprocessing = ce.BaseNEncoder(cols=["Age", "Sex"], return_df=True, base=3)
         fitted_dataset = preprocessing.fit_transform(self.ds_titanic_clean)
         output = inverse_transform(fitted_dataset, preprocessing)
-        pd.testing.assert_frame_equal(output, self.ds_titanic_clean)
+        pd.testing.assert_frame_equal(output, _normalize_str_dtypes(self.ds_titanic_clean))
 
     def test_inverse_transform_ce_onehot(self):
         """
@@ -47,7 +47,7 @@ class TestInverseTranform(unittest.TestCase):
         preprocessing = ce.OneHotEncoder(cols=["Age", "Sex"], return_df=True)
         fitted_dataset = preprocessing.fit_transform(self.ds_titanic_clean)
         output = inverse_transform(fitted_dataset, preprocessing)
-        pd.testing.assert_frame_equal(output, self.ds_titanic_clean)
+        pd.testing.assert_frame_equal(output, _normalize_str_dtypes(self.ds_titanic_clean))
 
     def test_inverse_transform_ce_binary(self):
         """
@@ -56,7 +56,7 @@ class TestInverseTranform(unittest.TestCase):
         preprocessing = ce.BinaryEncoder(cols=["Age", "Sex"], return_df=True)
         fitted_dataset = preprocessing.fit_transform(self.ds_titanic_clean)
         output = inverse_transform(fitted_dataset, preprocessing)
-        pd.testing.assert_frame_equal(output, self.ds_titanic_clean)
+        pd.testing.assert_frame_equal(output, _normalize_str_dtypes(self.ds_titanic_clean))
 
     def test_inverse_transform_ce_ordinal(self):
         """
@@ -65,4 +65,4 @@ class TestInverseTranform(unittest.TestCase):
         preprocessing = ce.OrdinalEncoder(cols=["Age", "Sex"], return_df=True)
         fitted_dataset = preprocessing.fit_transform(self.ds_titanic_clean)
         output = inverse_transform(fitted_dataset, preprocessing)
-        pd.testing.assert_frame_equal(output, self.ds_titanic_clean)
+        pd.testing.assert_frame_equal(output, _normalize_str_dtypes(self.ds_titanic_clean))

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -26,6 +26,8 @@ from shapash.explainer.multi_decorator import MultiDecorator
 from shapash.explainer.smart_state import SmartState
 from shapash.utils.check import check_model
 
+from shapash.utils.transform import _normalize_str_dtypes
+
 
 def init_sme_to_pickle_test():
     """
@@ -208,6 +210,7 @@ class TestSmartExplainer(unittest.TestCase):
         df_encoded = encoder_fitted.transform(df)
         output = df[["x1", "x2"]].copy()
         output["x2"] = ["single", "married", "single", "divorced", "married"]
+        output = _normalize_str_dtypes(output)  # Ensure consistent string dtypes for comparison
         clf = cb.CatBoostClassifier(n_estimators=1).fit(df_encoded[["x1", "x2"]], df_encoded["y"])
 
         postprocessing_1 = {"x2": {"type": "transcoding", "rule": {"S": "single", "M": "married", "D": "divorced"}}}
@@ -234,8 +237,8 @@ class TestSmartExplainer(unittest.TestCase):
         assert hasattr(xpl_postprocessing2, "postprocessing")
         assert hasattr(xpl_postprocessing3, "preprocessing")
         assert hasattr(xpl_postprocessing3, "postprocessing")
-        pd.testing.assert_frame_equal(xpl_postprocessing1.x_init, output)
-        pd.testing.assert_frame_equal(xpl_postprocessing2.x_init, output)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(xpl_postprocessing1.x_init), output)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(xpl_postprocessing2.x_init), output)
         assert xpl_postprocessing1.preprocessing == encoder_fitted
         assert xpl_postprocessing2.preprocessing == encoder_fitted
         assert xpl_postprocessing1.postprocessing == postprocessing_1
@@ -795,7 +798,7 @@ class TestSmartExplainer(unittest.TestCase):
             dtype=object,
         )
         expected["pred"] = expected["pred"].astype(int)
-        assert not pd.testing.assert_frame_equal(expected, output)
+        assert not pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), _normalize_str_dtypes(output))
 
     def predict_proba(self, arg1, arg2):
         """
@@ -941,7 +944,7 @@ class TestSmartExplainer(unittest.TestCase):
             dtype=object,
         )
         expected["pred"] = expected["pred"].astype(int)
-        pd.testing.assert_frame_equal(expected, output)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), _normalize_str_dtypes(output))
 
     def test_compute_features_import_1(self):
         """

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -1743,7 +1743,7 @@ class TestSmartPlotter(unittest.TestCase):
         title_1 = "Compare plot - index : <b>A</b> ; <b>B</b><span style='font-size: 12px;'><br /></span>"
 
         fig_0 = list()
-        x0 = contributions1.to_numpy()
+        x0 = contributions1.to_numpy().copy()
         x0.sort(axis=1)
         for i in range(2):
             fig_0.append(
@@ -1761,7 +1761,7 @@ class TestSmartPlotter(unittest.TestCase):
             )
 
         fig_1 = list()
-        x1 = contributions2.to_numpy()
+        x1 = contributions2.to_numpy().copy()
         x1.sort(axis=1)
         for i in range(2):
             fig_1.append(

--- a/tests/unit_tests/explainer/test_smart_state.py
+++ b/tests/unit_tests/explainer/test_smart_state.py
@@ -9,6 +9,8 @@ import pandas as pd
 
 from shapash.explainer.smart_state import SmartState
 
+from shapash.utils.transform import _normalize_str_dtypes
+
 
 class TestSmartState(unittest.TestCase):
     """
@@ -264,7 +266,7 @@ class TestSmartState(unittest.TestCase):
             index=[0, 1, 2],
             dtype=object,
         )
-        assert not pd.testing.assert_frame_equal(expected, output)
+        assert not pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), _normalize_str_dtypes(output))
 
     @patch("shapash.explainer.smart_state.compute_features_import")
     def test_compute_features_import(self, mock_compute_features_import):

--- a/tests/unit_tests/utils/test_category_encoders_backend.py
+++ b/tests/unit_tests/utils/test_category_encoders_backend.py
@@ -11,7 +11,7 @@ import pandas as pd
 import xgboost
 from sklearn.ensemble import GradientBoostingClassifier
 
-from shapash.utils.transform import apply_preprocessing, get_col_mapping_ce, inverse_transform
+from shapash.utils.transform import apply_preprocessing, get_col_mapping_ce, inverse_transform, _normalize_str_dtypes
 
 
 class TestInverseTransformCaterogyEncoder(unittest.TestCase):
@@ -113,7 +113,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
             result5, [enc_onehot, enc_binary, enc_ordinal, enc_basen, enc_target, input_dict1, list_dict]
         )
 
-        pd.testing.assert_frame_equal(expected, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_3(self):
         """
@@ -137,7 +137,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.TargetEncoder(cols=["city", "state"]).fit(train, y)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(expected, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_4(self):
         """
@@ -150,7 +150,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(expected, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_5(self):
         """
@@ -160,7 +160,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.OrdinalEncoder(handle_missing="value", handle_unknown="value")
         result = enc.fit_transform(train)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_6(self):
         """
@@ -170,7 +170,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.OrdinalEncoder(handle_missing="return_nan", handle_unknown="value")
         result = enc.fit_transform(train)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_7(self):
         """
@@ -182,7 +182,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_8(self):
         """
@@ -194,7 +194,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_9(self):
         """
@@ -221,7 +221,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.OrdinalEncoder(cols=["city", "state"])
         enc.fit(data)
         original = inverse_transform(test, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_11(self):
         """
@@ -240,7 +240,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.BinaryEncoder(cols=["city", "state"]).fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_12(self):
         """
@@ -250,7 +250,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.BaseNEncoder(base=2)
         result = enc.fit_transform(train)
         inversed_result = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, inversed_result)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), inversed_result)
 
     def test_inverse_transform_13(self):
         """
@@ -260,7 +260,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.BaseNEncoder(handle_missing="value", handle_unknown="value")
         result = enc.fit_transform(train)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_14(self):
         """
@@ -272,7 +272,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         result = enc.fit_transform(train)
         original = inverse_transform(result, enc)
 
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_15(self):
         """
@@ -286,7 +286,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         result = enc.transform(test)
         original = inverse_transform(result, enc)
 
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_16(self):
         """
@@ -299,7 +299,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(expected, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_17(self):
         """
@@ -310,7 +310,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.BaseNEncoder(cols=["city", "state"], handle_missing="value", handle_unknown="return_nan")
         enc.fit(train)
         original = inverse_transform(test, enc)
-        pd.testing.assert_frame_equal(original, train)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_18(self):
         """
@@ -320,7 +320,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         value = pd.DataFrame({"match": pd.Series("box_-1"), "match_box": pd.Series(-1)})
         transformed = encoder.fit_transform(value)
         inversed_result = inverse_transform(transformed, encoder)
-        pd.testing.assert_frame_equal(value, inversed_result)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(value), inversed_result)
 
     def test_inverse_transform_19(self):
         """
@@ -330,7 +330,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         value = pd.DataFrame({"match": pd.Series("box_-1"), "match_box": pd.Series(-1)})
         transformed = encoder.fit_transform(value)
         inversed_result = inverse_transform(transformed, encoder)
-        pd.testing.assert_frame_equal(value, inversed_result)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(value), inversed_result)
 
     def test_inverse_transform_20(self):
         """
@@ -340,7 +340,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.OneHotEncoder(handle_missing="value", handle_unknown="value")
         result = enc.fit_transform(train)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_21(self):
         """
@@ -350,7 +350,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc = ce.OneHotEncoder(handle_missing="return_nan", handle_unknown="value")
         result = enc.fit_transform(train)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_22(self):
         """
@@ -363,7 +363,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_23(self):
         """
@@ -375,7 +375,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(train, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(train), original)
 
     def test_inverse_transform_24(self):
         """
@@ -388,7 +388,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         enc.fit(train)
         result = enc.transform(test)
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(expected, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_inverse_transform_25(self):
         """
@@ -406,7 +406,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
         input_dict["mapping"] = pd.Series(data=["US", "FR-1", "FR-2"], index=["US", "FR", "FR"])
         input_dict["data_type"] = "object"
         result = inverse_transform(data, input_dict)
-        pd.testing.assert_frame_equal(result, expected)
+        pd.testing.assert_frame_equal(result, _normalize_str_dtypes(expected))
 
     def test_inverse_transform_26(self):
         """
@@ -500,7 +500,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
             result5, [enc_onehot, enc_binary, enc_ordinal, enc_basen, enc_target, input_dict1, list_dict]
         )
 
-        pd.testing.assert_frame_equal(expected, original)
+        pd.testing.assert_frame_equal(_normalize_str_dtypes(expected), original)
 
     def test_transform_ce_1(self):
         """

--- a/tests/unit_tests/utils/test_columntransformer_backend.py
+++ b/tests/unit_tests/utils/test_columntransformer_backend.py
@@ -21,7 +21,7 @@ from shapash.utils.columntransformer_backend import (
     get_list_features_names,
     get_names,
 )
-from shapash.utils.transform import apply_preprocessing, inverse_transform
+from shapash.utils.transform import apply_preprocessing, inverse_transform, _normalize_str_dtypes
 
 # TODO
 # StandardScaler return object vs float vs int
@@ -64,7 +64,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1", "col3_0", "col3_1", "col4_0", "col4_1"]
         result.index = ["index1", "index2", "index3"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_2(self):
         """
@@ -102,7 +102,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1", "col3_0", "col3_1", "col4_0", "col4_1", "other"]
         result.index = ["index1", "index2", "index3"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_3(self):
         """
@@ -157,7 +157,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         list_dict = [input_dict2, input_dict3]
 
         original = inverse_transform(result, [enc, input_dict1, list_dict])
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_4(self):
         """
@@ -194,7 +194,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_5(self):
         """
@@ -223,7 +223,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_6(self):
         """
@@ -245,7 +245,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_7(self):
         """
@@ -274,7 +274,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_8(self):
         """
@@ -296,7 +296,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_9(self):
         """
@@ -325,7 +325,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_10(self):
         """
@@ -346,7 +346,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_11(self):
         """
@@ -369,7 +369,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_12(self):
         """
@@ -390,7 +390,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_13(self):
         """
@@ -419,7 +419,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_14(self):
         """
@@ -440,7 +440,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_15(self):
         """
@@ -469,7 +469,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1_0", "col1_1", "col2_0", "col2_1", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_16(self):
         """
@@ -490,7 +490,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_17(self):
         """
@@ -519,7 +519,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_18(self):
         """
@@ -546,7 +546,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_19(self):
         """
@@ -565,7 +565,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["col1", "col2"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_20(self):
         """
@@ -589,7 +589,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["num1", "num2", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_21(self):
         """
@@ -610,7 +610,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["num1", "num2"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_22(self):
         """
@@ -637,7 +637,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["num1", "num2", "other"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_inv_transform_ct_23(self):
         """
@@ -658,7 +658,7 @@ class TestInverseTransformColumnsTransformer(unittest.TestCase):
         result = pd.DataFrame(enc.transform(test))
         result.columns = ["num1", "num2"]
         original = inverse_transform(result, enc)
-        pd.testing.assert_frame_equal(original, expected)
+        pd.testing.assert_frame_equal(original, _normalize_str_dtypes(expected))
 
     def test_transform_ct_1(self):
         """


### PR DESCRIPTION
# Description
Fixes compatibility issues introduced by the pandas 3.0 migration.

# Main changes

### pandas 3.0 breaking changes addressed (#677 )

- **`StringDtype` as default for string columns**: pandas 3.0 now infers `StringDtype` instead of `object` for string columns and indexes. Added `_normalize_str_dtypes()` utility to cast any `StringDtype` variant back to `object` for consistent output across pandas 2.x and 3.x. Applied at the output of `inverse_transform()` and normalized in affected test fixtures.

- **Read-only arrays from `.to_numpy()`**: pandas 3.0 returns read-only arrays from `.to_numpy()`. Fixed by adding `.copy()` after `.to_numpy()` calls where in-place operations (e.g. `.sort()`) are performed — in both `compare_plot()` and the corresponding test.

- **Integer indexing on string-indexed Series**: pandas 3.0 no longer falls back to positional indexing when accessing a `Series` with a string index using integer keys. Fixed by passing `.to_numpy()` instead of a pandas `Series` to LIME's `explain_instance()` in `lime_backend.py` (both classification and regression branches).