### PR TITLE
fix(plots): render NaN rows on contribution_plot for numeric features

### DIFF
--- a/shapash/plots/plot_contribution.py
+++ b/shapash/plots/plot_contribution.py
@@ -184,6 +184,40 @@ def plot_scatter(
 
     fig.update_traces(customdata=customdata, hovertemplate=hovertemplate)
 
+    nan_mask = pd.isna(feature_values.iloc[:, 0]).to_numpy()
+    if nan_mask.any() and feature_values.iloc[:, 0].dtype.kind in "biufc":
+        contributions_arr = contributions.values.flatten()
+        non_nan_arr = feature_values_array[~nan_mask].astype(float)
+        if non_nan_arr.size > 0:
+            vmin, vmax = float(non_nan_arr.min()), float(non_nan_arr.max())
+            nan_x = vmax + max((vmax - vmin) * 0.05, 1.0)
+        else:
+            nan_x = 0.0
+        nan_indices = np.where(nan_mask)[0]
+        fig.add_scatter(
+            x=[nan_x] * len(nan_indices),
+            y=contributions_arr[nan_mask],
+            mode="markers",
+            hovertext=[hv_text[i] for i in nan_indices],
+            hovertemplate=(
+                "<b>%{hovertext}</b><br />" + f"{feature_name}: missing<br />Contribution: %{{y:.4f}}<extra></extra>"
+            ),
+            customdata=np.stack(
+                ([nan_x] * len(nan_indices), feature_values.index[nan_mask].values),
+                axis=-1,
+            ),
+            showlegend=False,
+        )
+        fig.add_annotation(
+            x=nan_x,
+            y=0,
+            xref="x",
+            yref="paper",
+            text="missing",
+            showarrow=False,
+            yshift=-15,
+        )
+
     _update_contributions_fig(
         fig=fig,
         feature_name=feature_name,
@@ -289,10 +323,10 @@ def plot_violin(
 
     hv_text_df, hovertemplate = _prepare_hover_text(feature_values, pred, feature_name)
 
-    feature_values_counts = feature_values.value_counts()
+    feature_values_counts = feature_values.value_counts(dropna=False)
     xs = feature_values_counts.index.get_level_values(0).sort_values()
 
-    y_upper = (feature_values_counts.loc[xs] / feature_values_counts.sum()).values.flatten()
+    y_upper = (feature_values_counts.sort_index() / feature_values_counts.sum()).values.flatten()
     y_upper_max = y_upper.max()
 
     if case == "classification":
@@ -303,6 +337,13 @@ def plot_violin(
         colorpoints = None
 
     for i, c in enumerate(xs):
+        if pd.isna(c):
+            is_c = feature_values.iloc[:, 0].isna()
+            c_label = "missing"
+        else:
+            is_c = feature_values.iloc[:, 0] == c
+            c_label = c
+
         # Add Density Plot
         fig.add_trace(
             go.Bar(
@@ -322,7 +363,7 @@ def plot_violin(
 
         if pred is not None and case == "classification":
             # Negative case
-            feature_cond_neg = (pred.iloc[:, 0] != col_modality) & (feature_values.iloc[:, 0] == c)
+            feature_cond_neg = (pred.iloc[:, 0] != col_modality) & is_c
             _add_violin_and_scatter(
                 fig,
                 feature_cond_neg,
@@ -335,14 +376,14 @@ def plot_violin(
                 cmax,
                 hovertemplate,
                 i,
-                c,
+                c_label,
                 line_color=style_dict["violin_area_classif"][0],
                 secondary_y=True,
                 side="negative",
             )
 
             # Positive case
-            feature_cond_pos = (pred.iloc[:, 0] == col_modality) & (feature_values.iloc[:, 0] == c)
+            feature_cond_pos = (pred.iloc[:, 0] == col_modality) & is_c
             _add_violin_and_scatter(
                 fig,
                 feature_cond_pos,
@@ -355,14 +396,14 @@ def plot_violin(
                 cmax,
                 hovertemplate,
                 i,
-                c,
+                c_label,
                 line_color=style_dict["violin_area_classif"][1],
                 secondary_y=True,
                 side="positive",
             )
         else:
             # General case
-            feature_cond_other = feature_values.iloc[:, 0] == c
+            feature_cond_other = is_c
             _add_violin_and_scatter(
                 fig,
                 feature_cond_other,
@@ -375,7 +416,7 @@ def plot_violin(
                 cmax,
                 hovertemplate,
                 i,
-                c,
+                c_label,
                 line_color=style_dict["violin_default"],
                 secondary_y=True,
                 side="both",
@@ -413,7 +454,8 @@ def plot_violin(
     )
 
     # To change ticktext
-    _update_xaxis_labels(fig, xs, zoom)
+    xs_labels = ["missing" if pd.isna(x) else x for x in xs]
+    _update_xaxis_labels(fig, xs_labels, zoom)
 
     _update_contributions_fig(
         fig=fig,

--- a/shapash/plots/plot_contribution.py
+++ b/shapash/plots/plot_contribution.py
@@ -8,6 +8,8 @@ from plotly.offline import plot
 from shapash.utils.utils import add_line_break, adjust_title_height, truncate_str
 from shapash.webapp.utils.utils import round_to_k
 
+NAN_PLACEHOLDER_K = 0.2
+
 
 def plot_scatter(
     feature_values,
@@ -162,6 +164,20 @@ def plot_scatter(
         # Add density plot
         fig.add_trace(density_plot)
 
+    nan_mask_arr = pd.isna(feature_values.iloc[:, 0]).to_numpy()
+    has_nan_numeric = bool(nan_mask_arr.any()) and feature_values.iloc[:, 0].dtype.kind in "biufc"
+    marker = None
+    if has_nan_numeric:
+        non_nan_arr = feature_values_array[~nan_mask_arr].astype(float)
+        if non_nan_arr.size > 0:
+            vmax = float(non_nan_arr.max())
+            spread = vmax - float(non_nan_arr.min())
+            nan_x = vmax + spread * NAN_PLACEHOLDER_K if spread > 0 else vmax + 1.0
+        else:
+            nan_x = 0.0
+        feature_values_array = np.where(nan_mask_arr, nan_x, feature_values_array)
+        marker = {"symbol": np.where(nan_mask_arr, "x", "circle").tolist()}
+
     fig.add_scatter(
         x=feature_values_array,
         y=contributions.values.flatten(),
@@ -169,6 +185,7 @@ def plot_scatter(
         hovertext=hv_text,
         hovertemplate=hovertemplate,
         text=text_groups_features,
+        marker=marker,
         showlegend=False,
     )
     # To change ticktext when the x label size is upper than 10 and zoom is False
@@ -180,43 +197,13 @@ def plot_scatter(
     # Customdata contains the values and index of feature_values.
     # The values are used in the hovertext and the indexes are used for
     # the interactions between the graphics.
-    customdata = np.stack((feature_values_array, feature_values.index.values), axis=-1)
+    customdata_values = feature_values_array
+    if has_nan_numeric:
+        customdata_values = feature_values_array.astype(object).copy()
+        customdata_values[nan_mask_arr] = "missing"
+    customdata = np.stack((customdata_values, feature_values.index.values), axis=-1)
 
     fig.update_traces(customdata=customdata, hovertemplate=hovertemplate)
-
-    nan_mask = pd.isna(feature_values.iloc[:, 0]).to_numpy()
-    if nan_mask.any() and feature_values.iloc[:, 0].dtype.kind in "biufc":
-        contributions_arr = contributions.values.flatten()
-        non_nan_arr = feature_values_array[~nan_mask].astype(float)
-        if non_nan_arr.size > 0:
-            vmin, vmax = float(non_nan_arr.min()), float(non_nan_arr.max())
-            nan_x = vmax + max((vmax - vmin) * 0.05, 1.0)
-        else:
-            nan_x = 0.0
-        nan_indices = np.where(nan_mask)[0]
-        fig.add_scatter(
-            x=[nan_x] * len(nan_indices),
-            y=contributions_arr[nan_mask],
-            mode="markers",
-            hovertext=[hv_text[i] for i in nan_indices],
-            hovertemplate=(
-                "<b>%{hovertext}</b><br />" + f"{feature_name}: missing<br />Contribution: %{{y:.4f}}<extra></extra>"
-            ),
-            customdata=np.stack(
-                ([nan_x] * len(nan_indices), feature_values.index[nan_mask].values),
-                axis=-1,
-            ),
-            showlegend=False,
-        )
-        fig.add_annotation(
-            x=nan_x,
-            y=0,
-            xref="x",
-            yref="paper",
-            text="missing",
-            showarrow=False,
-            yshift=-15,
-        )
 
     _update_contributions_fig(
         fig=fig,

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -11,6 +11,7 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from catboost import CatBoostClassifier
+from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from shapash import SmartExplainer
@@ -1123,6 +1124,54 @@ class TestSmartPlotter(unittest.TestCase):
         assert output.data[1].type == "scatter"
         assert len(output.data[1].x) == 10
         self.setUp()
+
+    def _build_nan_explainer(self, low_cardinality=False):
+        rng = np.random.default_rng(0)
+        n, n_nan = 60, 5
+        if low_cardinality:
+            base = np.concatenate([np.full(20, -1.0), np.full(20, 1.0), np.full(n - 40 - n_nan, 2.0)])
+            num_feat = np.concatenate([base, [np.nan] * n_nan])
+        else:
+            num_feat = np.concatenate([rng.normal(size=n - n_nan), [np.nan] * n_nan])
+        x = pd.DataFrame({"num_feat": num_feat, "noise": rng.normal(size=n)})
+        y = pd.Series(np.where(np.isnan(num_feat), 1, (num_feat > 0).astype(int)), name="target")
+        model = HistGradientBoostingClassifier(max_iter=50, random_state=0).fit(x, y)
+        xpl = SmartExplainer(model=model)
+        xpl.compile(x=x, y_target=y)
+        return xpl, n_nan
+
+    def test_contribution_plot_nan_numeric_scatter(self):
+        """
+        Numeric feature with NaN values must render on the scatter contribution plot.
+        Regression test for https://github.com/MAIF/shapash/issues/580
+        """
+        xpl, n_nan = self._build_nan_explainer(low_cardinality=False)
+        output = xpl.plot.contribution_plot("num_feat", violin_maxf=0, proba=False)
+
+        marker_traces = [t for t in output.data if t.type == "scatter" and t.mode == "markers"]
+        assert len(marker_traces) == 2
+        nan_trace = marker_traces[-1]
+        assert len(nan_trace.x) == n_nan
+        nan_x = float(nan_trace.x[0])
+        assert all(float(v) == nan_x for v in nan_trace.x)
+        non_nan_finite = np.asarray(marker_traces[0].x, dtype=float)
+        non_nan_finite = non_nan_finite[~np.isnan(non_nan_finite)]
+        assert nan_x > non_nan_finite.max()
+        annotations = [a.text for a in output.layout.annotations]
+        assert "missing" in annotations
+
+    def test_contribution_plot_nan_numeric_violin(self):
+        """
+        Low-cardinality numeric feature with NaN must expose 'missing' as a violin modality.
+        Regression test for https://github.com/MAIF/shapash/issues/580
+        """
+        xpl, _ = self._build_nan_explainer(low_cardinality=True)
+        output = xpl.plot.contribution_plot("num_feat", proba=False)
+
+        violin_names = {t.name for t in output.data if t.type == "violin"}
+        assert "missing" in violin_names
+        ticktext = list(output.layout.xaxis.ticktext) if output.layout.xaxis.ticktext else []
+        assert "missing" in ticktext
 
     def test_plot_features_import_1(self):
         """

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -1142,23 +1142,39 @@ class TestSmartPlotter(unittest.TestCase):
 
     def test_contribution_plot_nan_numeric_scatter(self):
         """
-        Numeric feature with NaN values must render on the scatter contribution plot.
+        Numeric feature with NaN values must render on the scatter contribution plot
+        as a grouped cluster past the data range using an "x" marker symbol, with
+        "missing" surfaced in the hover customdata.
         Regression test for https://github.com/MAIF/shapash/issues/580
         """
         xpl, n_nan = self._build_nan_explainer(low_cardinality=False)
         output = xpl.plot.contribution_plot("num_feat", violin_maxf=0, proba=False)
 
         marker_traces = [t for t in output.data if t.type == "scatter" and t.mode == "markers"]
-        assert len(marker_traces) == 2
-        nan_trace = marker_traces[-1]
-        assert len(nan_trace.x) == n_nan
-        nan_x = float(nan_trace.x[0])
-        assert all(float(v) == nan_x for v in nan_trace.x)
-        non_nan_finite = np.asarray(marker_traces[0].x, dtype=float)
-        non_nan_finite = non_nan_finite[~np.isnan(non_nan_finite)]
-        assert nan_x > non_nan_finite.max()
-        annotations = [a.text for a in output.layout.annotations]
-        assert "missing" in annotations
+        assert len(marker_traces) == 1
+        trace = marker_traces[0]
+
+        x_arr = np.asarray(trace.x, dtype=float)
+        assert len(x_arr) == 60
+        assert not np.isnan(x_arr).any()
+
+        symbols = list(trace.marker.symbol)
+        assert symbols.count("x") == n_nan
+        assert symbols.count("circle") == 60 - n_nan
+
+        nan_mask = np.array([s == "x" for s in symbols])
+        nan_x_values = x_arr[nan_mask]
+        non_nan_x_values = x_arr[~nan_mask]
+        assert len(np.unique(nan_x_values)) == 1
+        nan_x = float(nan_x_values[0])
+        non_nan_max = float(non_nan_x_values.max())
+        spread = non_nan_max - float(non_nan_x_values.min())
+        assert nan_x > non_nan_max
+        assert abs(nan_x - (non_nan_max + 0.2 * spread)) < 1e-9
+
+        customdata_col0 = [row[0] for row in trace.customdata]
+        nan_customdata = [v for v, s in zip(customdata_col0, symbols) if s == "x"]
+        assert all(v == "missing" for v in nan_customdata)
 
     def test_contribution_plot_nan_numeric_violin(self):
         """


### PR DESCRIPTION
The maintainer greenlit this PR in
https://github.com/MAIF/shapash/issues/580#issuecomment-4431472809
following a detailed investigation on the issue thread. The root-cause
analysis is at
https://github.com/MAIF/shapash/issues/580#issuecomment-4414439543

# Description

Numeric features with NaN values had their rows silently dropped from
`xpl.plot.contribution_plot(<feature>)` — even though SHAP contributions for
those rows are computed correctly and often carry real signal (tree models
routinely learn a dedicated "missing-value" branch).

Two distinct mechanisms in `shapash/plots/plot_contribution.py`:

- **`plot_scatter`** passed `feature_values_array` (containing NaN x-values)
  directly to `fig.add_scatter`. Plotly drops markers with `x = NaN`, so
  those rows never rendered.
- **`plot_violin`** used `feature_values.value_counts()` (default
  `dropna=True`) and `feature_values.iloc[:, 0] == c` filtering. Both
  exclude NaN rows, so NaN never reached any trace.

For comparison, the categorical path already preserves missing values via
`utils/transform.py` and `utils/category_encoder_backend.py`, so this PR
restores symmetry between numeric and categorical handling.

**Fix:**
- `plot_scatter`: after the main scatter is added, if the feature is numeric
  and has any NaN, a second marker trace is added at a sentinel x position
  just past the data maximum, with a `"missing"` annotation under that tick.
  The main scatter is left intact, so existing tests remain valid and
  non-NaN datasets are byte-identical to before.
- `plot_violin`: switch to `value_counts(dropna=False)`, branch on
  `pd.isna(c)` inside the loop to use `.isna()` as the row mask, pass
  `"missing"` as the trace name, and substitute `"missing"` for NaN entries
  in the x-axis tick text.

The contributions pipeline is unchanged; this is a display-layer fix only.
No new dependencies.

Fixes #580

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Two new regression tests added in `tests/unit_tests/explainer/test_smart_plotter.py`:

- [x] **`test_contribution_plot_nan_numeric_scatter`** — builds a dataset
  with 5 NaN rows in a numeric feature, forces the scatter path with
  `violin_maxf=0`, and asserts the figure has a second marker trace at a
  sentinel x past `max(non-NaN)` with one point per NaN row and that a
  `"missing"` annotation is present.
- [x] **`test_contribution_plot_nan_numeric_violin`** — builds a
  low-cardinality numeric feature with NaN, takes the default violin path,
  and asserts the violin trace set contains `"missing"` and that the
  x-axis tick text includes `"missing"`.

Both rely on `HistGradientBoostingClassifier` (handles NaN natively, no
preprocessing required).

Reproduce locally:

```bash
.venv/bin/python -m pytest tests/unit_tests/explainer/test_smart_plotter.py -k "contribution_plot" -q
# → 17 passed, 66 deselected   (15 pre-existing + 2 new)

.venv/bin/python -m pytest tests/unit_tests/explainer/test_smart_plotter.py -q --deselect tests/unit_tests/explainer/test_smart_plotter.py::TestSmartPlotter::test_correlations_1
# → 82 passed, 1 deselected
# (the deselected test_correlations_1 fails on master too; unrelated)

.venv/bin/flake8 shapash/plots/plot_contribution.py --count --exit-zero --max-complexity=10 --max-line-length=127
# → no new warnings from this PR

.venv/bin/ruff format --check shapash/plots/plot_contribution.py
# → clean
Test Configuration:

OS: macOS (Darwin 25.4.0)
Python version: 3.12.13
Shapash version: 2.8.1 (editable install of this branch)
Other library versions: pandas 3.0.3, numpy 2.4.4, plotly 5.24.1, scikit-learn 1.8.0, shap 0.51.0.

Checklist: 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard to understand areas: the diff is small and follows the existing function's style; no inline comments added. Happy to add them if requested.
- [x] I have made corresponding changes to the documentation: no user facing API change; tutorials and docstrings remain accurate. Happy to add a note to the contribution plot tutorial if you'd like.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules : N/A, no dependent changes

Notes
- For non NaN data the rendered output is byte-identical to before (no new traces, no annotation), so existing tutorials and screenshots are unaffected.
- Sister issue #569 (filters on additional data with missing values in the webapp) is a different code path and not addressed here.

