### PR TITLE
fix(report): write HTML export as utf-8

### DIFF
--- a/shapash/report/generation.py
+++ b/shapash/report/generation.py
@@ -90,5 +90,5 @@ def export_and_save_report(working_dir: str, output_file: str):
     )
     (body, resources) = exporter.from_filename(filename=os.path.join(working_dir, "base_report.ipynb"))
 
-    with open(output_file, "w") as file:
+    with open(output_file, "w", encoding="utf-8") as file:
         file.write(body)

--- a/tests/integration_tests/test_report_generation.py
+++ b/tests/integration_tests/test_report_generation.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import MagicMock, mock_open, patch
 
 import catboost as cb
 import category_encoders as ce
@@ -151,3 +152,28 @@ class TestGeneration(unittest.TestCase):
         export_and_save_report(working_dir=tmp_dir_path, output_file=outfile)
         assert os.path.exists(outfile)
         shutil.rmtree(tmp_dir_path)
+
+    def test_export_and_save_report_writes_utf8(self):
+        """
+        Regression test for https://github.com/MAIF/shapash/issues/699:
+        export_and_save_report must pass encoding='utf-8' to open(), otherwise
+        on Windows (cp1252 default) any non-Latin1 character in the HTML body
+        raises UnicodeEncodeError.
+        """
+        fake_html = "café — déjà vu — résumé"
+        fake_exporter = MagicMock()
+        fake_exporter.from_filename.return_value = (fake_html, {})
+
+        m = mock_open()
+        with (
+            patch("shapash.report.generation.HTMLExporter", return_value=fake_exporter),
+            patch("shapash.report.generation.open", m, create=True),
+        ):
+            export_and_save_report(working_dir="dummy", output_file="dummy.html")
+
+        write_calls = [c for c in m.call_args_list if len(c.args) >= 2 and c.args[1] == "w"]
+        assert write_calls, "expected at least one write-mode open() call"
+        for call in write_calls:
+            assert call.kwargs.get("encoding") == "utf-8", (
+                f"export_and_save_report must call open(..., 'w', encoding='utf-8'); got {call}"
+            )


### PR DESCRIPTION
# Description

`export_and_save_report()` writes the rendered HTML report via
`open(output_file, "w")` without an explicit `encoding=`, so the
file is written with `locale.getpreferredencoding(False)`. On Windows
that's `cp1252`, which raises
`UnicodeEncodeError: 'charmap' codec can't encode character ...`
whenever the nbconvert HTML body contains non-Latin1 characters
(feature names with accents, user-supplied text in additional data,
dataset string values, etc.).

The reporter (@dalestee) diagnosed the issue and prescribed the fix in
the issue body. This PR applies that fix exactly: add
`encoding="utf-8"` to the `open()` call at
[`shapash/report/generation.py:93`](https://github.com/MAIF/shapash/blob/master/shapash/report/generation.py#L93).

Grepped the rest of `shapash/` for sibling sites — every other
write-side `open()` call is in binary mode and every read-side one
touches ASCII-only bundled JSON, so this is the only line that needs
to change.

Fixes #699

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added `test_export_and_save_report_writes_utf8` in
`tests/integration_tests/test_report_generation.py`. It mocks
`HTMLExporter` and the local `open` binding in
`shapash.report.generation`, calls `export_and_save_report`, and
asserts that every write-mode `open()` call carries
`encoding="utf-8"`.

The test uses `mock.patch` rather than monkeypatching `locale.getpreferredencoding`,
because Python 3.12 resolves `open()`'s default encoding at a lower
level than the `locale` module exposes — monkeypatching `locale` no
longer changes the actual behavior. A contract test on the call
signature is the most reliable way to catch a future regression on
CI runners that default to UTF-8.

- [x] `pytest tests/integration_tests/test_report_generation.py -q` → **8 passed** (7 pre-existing + 1 new)
- [x] `ruff format --check shapash/report/generation.py tests/integration_tests/test_report_generation.py` → clean

**Test Configuration**:
* OS: macOS 
* Python version: 3.12.13
* Shapash version: 2.8.1 (editable install of this branch)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard to understand areas — only a docstring on the new test linking the bug; the fix itself is one line
- [x] I have made corresponding changes to the documentation — N/A, no user-facing API change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules — N/A, no dependent changes