### PR TITLE
fix doc for pandas 3

### DIFF
--- a/tutorial/generate_report/shapash_report_example.py
+++ b/tutorial/generate_report/shapash_report_example.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     y_df = house_df["SalePrice"]
     X_df = house_df[house_df.columns.difference(["SalePrice"])]
 
-    categorical_features = [col for col in X_df.columns if X_df[col].dtype == "object"]
+    categorical_features = [col for col in X_df.columns if X_df[col].dtype == "str"]
 
     encoder = OrdinalEncoder(cols=categorical_features, handle_unknown="ignore", return_df=True).fit(X_df)
 


### PR DESCRIPTION
Replace line
```python
categorical_features = [col for col in X_df.columns if X_df[col].dtype == "object"]
```
by
```python
categorical_features = [col for col in X_df.columns if X_df[col].dtype == "str"]
```
in `shapash_report_example.py` to align with pandas 3 typing policy.