### PR TITLE
feat(smartpredictor): add version/schema manifest sidecar to save/load

### DIFF
--- a/shapash/explainer/smart_predictor.py
+++ b/shapash/explainer/smart_predictor.py
@@ -31,7 +31,7 @@ from shapash.utils.check import (
     check_y,
 )
 from shapash.utils.columntransformer_backend import columntransformer
-from shapash.utils.io import save_pickle
+from shapash.utils.io import _build_predictor_manifest, _save_manifest, save_pickle
 from shapash.utils.model import predict_proba
 from shapash.utils.transform import adapt_contributions, apply_postprocessing, apply_preprocessing, preprocessing_tolist
 
@@ -577,8 +577,16 @@ class SmartPredictor:
         >>> predictor.save('path_to_pkl/predictor.pkl')
         >>> from shapash.utils.load_smartpredictor import load_smartpredictor
         >>> predictor_load = load_smartpredictor('path_to_pkl/predictor.pkl')
+
+        A sidecar manifest ``path + ".manifest.json"`` is written alongside the pickle
+        with the shapash version, model framework version, and a schema fingerprint.
+        ``load_smartpredictor`` uses it to detect version skew or schema tampering at
+        load time. The pickle remains a valid standalone artifact: predictors saved by
+        older versions of shapash without a manifest still load, with a
+        ``DeprecationWarning``.
         """
         save_pickle(self, path)
+        _save_manifest(_build_predictor_manifest(self), path)
 
     def apply_preprocessing(self):
         """

--- a/shapash/utils/io.py
+++ b/shapash/utils/io.py
@@ -2,7 +2,16 @@
 IO module
 """
 
+import datetime
+import hashlib
+import json
+import os
 import pickle
+import sys
+import warnings
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from typing import Any, Optional
 
 try:
     import yaml
@@ -10,6 +19,15 @@ try:
     _is_yaml_available = True
 except ImportError:
     _is_yaml_available = False
+
+MANIFEST_SUFFIX = ".manifest.json"
+
+_MODEL_FRAMEWORK_MAP = {
+    "sklearn": "scikit-learn",
+    "xgboost": "xgboost",
+    "lightgbm": "lightgbm",
+    "catboost": "catboost",
+}
 
 
 def save_pickle(obj, path, protocol=pickle.HIGHEST_PROTOCOL):
@@ -94,3 +112,145 @@ def load_yml(path):
         d = yaml.full_load(f)
 
     return d
+
+
+def _try_package_version(package_name: Optional[str]) -> Optional[str]:
+    """Return the installed version of ``package_name`` via importlib.metadata, or ``None``."""
+    if not package_name:
+        return None
+    try:
+        return _pkg_version(package_name)
+    except PackageNotFoundError:
+        return None
+
+
+def _detect_model_framework(model: Any) -> dict:
+    """
+    Inspect ``model`` and return a ``{"name", "version"}`` dict describing its framework.
+
+    Recognised frameworks: scikit-learn, xgboost, lightgbm, catboost. Anything else falls
+    through with the top-level module name as the framework name.
+    """
+    module = type(model).__module__ or ""
+    top = module.split(".")[0]
+    name = _MODEL_FRAMEWORK_MAP.get(top, top or "unknown")
+    version = _try_package_version(top) if top else None
+    return {"name": name, "version": version}
+
+
+def _compute_schema_fingerprint(predictor: Any) -> str:
+    """
+    Return a deterministic SHA-256 fingerprint of the predictor's user-facing schema
+    (``features_dict``, ``features_types``, ``columns_dict``, ``label_dict``).
+
+    Used at load time to detect schema tampering or stale manifests independently of
+    the pickle contents.
+    """
+    columns_dict_str_keys = {str(k): v for k, v in (predictor.columns_dict or {}).items()}
+    canonical = json.dumps(
+        {
+            "features_dict": predictor.features_dict,
+            "features_types": predictor.features_types,
+            "columns_dict": columns_dict_str_keys,
+            "label_dict": predictor.label_dict,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _build_predictor_manifest(predictor: Any) -> dict:
+    """Return the manifest dict describing the runtime state used to save ``predictor``."""
+    from shapash.__version__ import __version__ as shapash_version
+
+    return {
+        "shapash_version": shapash_version,
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "model_framework": _detect_model_framework(predictor.model),
+        "shap_version": _try_package_version("shap"),
+        "schema_fingerprint": _compute_schema_fingerprint(predictor),
+        "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+
+
+def _save_manifest(manifest: dict, predictor_path: str) -> str:
+    """Write ``manifest`` as a sidecar JSON next to the pickle. Returns the manifest path."""
+    manifest_path = predictor_path + MANIFEST_SUFFIX
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False, sort_keys=True)
+    return manifest_path
+
+
+def _load_manifest(predictor_path: str) -> Optional[dict]:
+    """Read the sidecar manifest for ``predictor_path``. Returns ``None`` if absent."""
+    manifest_path = predictor_path + MANIFEST_SUFFIX
+    if not os.path.exists(manifest_path):
+        return None
+    with open(manifest_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _parse_major_minor(version_str: str) -> Optional[tuple]:
+    """Parse a dotted version string into ``(major, minor)``. Returns ``None`` if unparseable."""
+    if not version_str:
+        return None
+    parts = version_str.split(".")
+    try:
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except (ValueError, IndexError):
+        return None
+    return (major, minor)
+
+
+def _check_predictor_manifest(manifest: dict, predictor: Any) -> None:
+    """
+    Validate ``manifest`` against the loaded ``predictor``. Raises ``ValueError`` on
+    critical mismatches (schema fingerprint, major shapash version) and emits
+    ``UserWarning`` for minor skews (minor shapash version, model framework version).
+    """
+    from shapash.__version__ import __version__ as current_shapash
+
+    expected_fp = manifest.get("schema_fingerprint")
+    actual_fp = _compute_schema_fingerprint(predictor)
+    if expected_fp and expected_fp != actual_fp:
+        raise ValueError(
+            f"SmartPredictor schema fingerprint mismatch: manifest has {expected_fp}, "
+            f"loaded predictor recomputes {actual_fp}. The pickle and manifest are out of sync "
+            "(possible tampering or stale manifest)."
+        )
+
+    saved_shapash = manifest.get("shapash_version", "") or ""
+    saved_v = _parse_major_minor(saved_shapash)
+    current_v = _parse_major_minor(current_shapash)
+    if saved_v is not None and current_v is not None:
+        if saved_v[0] != current_v[0]:
+            raise ValueError(
+                f"SmartPredictor saved with shapash {saved_shapash}, current is {current_shapash}. "
+                "Major version mismatch — re-fit and re-save the predictor."
+            )
+        if saved_v[1] != current_v[1]:
+            warnings.warn(
+                f"SmartPredictor saved with shapash {saved_shapash}, current is {current_shapash}. "
+                "Minor version skew; behaviour should still be compatible.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+    saved_fw = manifest.get("model_framework") or {}
+    current_fw = _detect_model_framework(predictor.model)
+    if (
+        saved_fw.get("name")
+        and saved_fw.get("name") == current_fw.get("name")
+        and saved_fw.get("version")
+        and current_fw.get("version")
+        and saved_fw["version"] != current_fw["version"]
+    ):
+        warnings.warn(
+            f"Model framework {saved_fw['name']} version differs: saved with {saved_fw['version']}, "
+            f"current is {current_fw['version']}. Predictions may differ subtly.",
+            UserWarning,
+            stacklevel=3,
+        )

--- a/shapash/utils/io.py
+++ b/shapash/utils/io.py
@@ -11,7 +11,9 @@ import sys
 import warnings
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
-from typing import Any, Optional
+from typing import Any
+
+from shapash.__version__ import __version__ as shapash_version
 
 try:
     import yaml
@@ -114,7 +116,7 @@ def load_yml(path):
     return d
 
 
-def _try_package_version(package_name: Optional[str]) -> Optional[str]:
+def _try_package_version(package_name: str | None) -> str | None:
     """Return the installed version of ``package_name`` via importlib.metadata, or ``None``."""
     if not package_name:
         return None
@@ -163,15 +165,13 @@ def _compute_schema_fingerprint(predictor: Any) -> str:
 
 def _build_predictor_manifest(predictor: Any) -> dict:
     """Return the manifest dict describing the runtime state used to save ``predictor``."""
-    from shapash.__version__ import __version__ as shapash_version
-
     return {
         "shapash_version": shapash_version,
         "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
         "model_framework": _detect_model_framework(predictor.model),
         "shap_version": _try_package_version("shap"),
         "schema_fingerprint": _compute_schema_fingerprint(predictor),
-        "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "saved_at": datetime.datetime.now(datetime.UTC).isoformat(),
     }
 
 
@@ -183,7 +183,7 @@ def _save_manifest(manifest: dict, predictor_path: str) -> str:
     return manifest_path
 
 
-def _load_manifest(predictor_path: str) -> Optional[dict]:
+def _load_manifest(predictor_path: str) -> dict | None:
     """Read the sidecar manifest for ``predictor_path``. Returns ``None`` if absent."""
     manifest_path = predictor_path + MANIFEST_SUFFIX
     if not os.path.exists(manifest_path):
@@ -192,7 +192,7 @@ def _load_manifest(predictor_path: str) -> Optional[dict]:
         return json.load(f)
 
 
-def _parse_major_minor(version_str: str) -> Optional[tuple]:
+def _parse_major_minor(version_str: str) -> tuple | None:
     """Parse a dotted version string into ``(major, minor)``. Returns ``None`` if unparseable."""
     if not version_str:
         return None
@@ -211,8 +211,6 @@ def _check_predictor_manifest(manifest: dict, predictor: Any) -> None:
     critical mismatches (schema fingerprint, major shapash version) and emits
     ``UserWarning`` for minor skews (minor shapash version, model framework version).
     """
-    from shapash.__version__ import __version__ as current_shapash
-
     expected_fp = manifest.get("schema_fingerprint")
     actual_fp = _compute_schema_fingerprint(predictor)
     if expected_fp and expected_fp != actual_fp:
@@ -224,16 +222,16 @@ def _check_predictor_manifest(manifest: dict, predictor: Any) -> None:
 
     saved_shapash = manifest.get("shapash_version", "") or ""
     saved_v = _parse_major_minor(saved_shapash)
-    current_v = _parse_major_minor(current_shapash)
+    current_v = _parse_major_minor(shapash_version)
     if saved_v is not None and current_v is not None:
         if saved_v[0] != current_v[0]:
             raise ValueError(
-                f"SmartPredictor saved with shapash {saved_shapash}, current is {current_shapash}. "
+                f"SmartPredictor saved with shapash {saved_shapash}, current is {shapash_version}. "
                 "Major version mismatch — re-fit and re-save the predictor."
             )
         if saved_v[1] != current_v[1]:
             warnings.warn(
-                f"SmartPredictor saved with shapash {saved_shapash}, current is {current_shapash}. "
+                f"SmartPredictor saved with shapash {saved_shapash}, current is {shapash_version}. "
                 "Minor version skew; behaviour should still be compatible.",
                 UserWarning,
                 stacklevel=3,

--- a/shapash/utils/load_smartpredictor.py
+++ b/shapash/utils/load_smartpredictor.py
@@ -2,11 +2,13 @@
 load_smartpredictor module
 """
 
+import warnings
+
 from shapash.explainer.smart_predictor import SmartPredictor
-from shapash.utils.io import load_pickle
+from shapash.utils.io import _check_predictor_manifest, _load_manifest, load_pickle
 
 
-def load_smartpredictor(path):
+def load_smartpredictor(path: str) -> SmartPredictor:
     """
     load_smartpredictor allows Shapash users to load SmartPredictor Object already saved into a pickle.
 
@@ -18,9 +20,29 @@ def load_smartpredictor(path):
     Example
     --------
     >>> predictor = load_smartpredictor('path_to_pkl/predictor.pkl')
+
+    Notes
+    -----
+    If a sidecar manifest ``path + ".manifest.json"`` is present (predictors saved
+    with shapash >= 2.10), provenance checks are run: the schema fingerprint and the
+    shapash major version must match the running environment, otherwise a
+    ``ValueError`` is raised. Minor shapash and model-framework version skews emit a
+    ``UserWarning``. Predictors saved without a manifest still load, with a
+    ``DeprecationWarning``.
     """
     predictor = load_pickle(path)
-    if isinstance(predictor, SmartPredictor):
-        return predictor
-    else:
+    if not isinstance(predictor, SmartPredictor):
         raise ValueError(f"{predictor} is not an instance of type SmartPredictor")
+
+    manifest = _load_manifest(path)
+    if manifest is None:
+        warnings.warn(
+            f"Loading SmartPredictor from {path} without a manifest sidecar. "
+            "Provenance checks (shapash version, schema fingerprint) are skipped. "
+            "Re-save the predictor to generate a manifest.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    else:
+        _check_predictor_manifest(manifest, predictor)
+    return predictor

--- a/tests/unit_tests/explainer/test_smart_predictor.py
+++ b/tests/unit_tests/explainer/test_smart_predictor.py
@@ -793,6 +793,9 @@ class TestSmartPredictor(unittest.TestCase):
         predictor.save(pkl_file)
         assert path.exists(pkl_file)
         os.remove(pkl_file)
+        manifest_file = pkl_file + ".manifest.json"
+        if path.exists(manifest_file):
+            os.remove(manifest_file)
 
     @patch("shapash.explainer.smart_predictor.SmartPredictor.check_model")
     @patch("shapash.utils.check.check_preprocessing_options")

--- a/tests/unit_tests/utils/test_load_smartpredictor.py
+++ b/tests/unit_tests/utils/test_load_smartpredictor.py
@@ -2,16 +2,27 @@
 Unit test smart predictor
 """
 
+import json
+import os
 import sys
+import tempfile
 import unittest
+import warnings
 from os import path
 from pathlib import Path
 
 import catboost as cb
 import numpy as np
 import pandas as pd
+import pytest
 
 from shapash import SmartExplainer
+from shapash.utils.io import (
+    MANIFEST_SUFFIX,
+    _build_predictor_manifest,
+    _compute_schema_fingerprint,
+    save_pickle,
+)
 from shapash.utils.load_smartpredictor import load_smartpredictor
 
 
@@ -47,3 +58,117 @@ class Test_load_smartpredictor(unittest.TestCase):
 
         assert all(attrib in attrib_predictor2 for attrib in attrib_predictor)
         assert all(attrib2 in attrib_predictor for attrib2 in attrib_predictor2)
+
+
+class TestSmartPredictorManifest(unittest.TestCase):
+    """
+    Tests for the SmartPredictor save/load manifest sidecar.
+    Regression tests for https://github.com/MAIF/shapash/issues/707 (Gap 1).
+    """
+
+    def _make_predictor(self):
+        y_pred = pd.DataFrame(data=np.array([1, 2]), columns=["pred"])
+        dataframe_x = pd.DataFrame([[1, 2, 4], [1, 2, 3]])
+        clf = cb.CatBoostClassifier(n_estimators=1).fit(dataframe_x, y_pred)
+        xpl = SmartExplainer(model=clf, features_dict={})
+        xpl.compile(x=dataframe_x, y_pred=y_pred)
+        return xpl.to_smartpredictor()
+
+    def test_save_writes_manifest_sidecar(self) -> None:
+        predictor = self._make_predictor()
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = os.path.join(tmp, "predictor.pkl")
+            predictor.save(pkl)
+            manifest_path = pkl + MANIFEST_SUFFIX
+            assert os.path.exists(manifest_path), "manifest sidecar not written"
+            with open(manifest_path, encoding="utf-8") as f:
+                manifest = json.load(f)
+            for key in (
+                "shapash_version",
+                "python_version",
+                "model_framework",
+                "shap_version",
+                "schema_fingerprint",
+                "saved_at",
+            ):
+                assert key in manifest, f"manifest missing '{key}'"
+            assert manifest["schema_fingerprint"].startswith("sha256:")
+            assert manifest["model_framework"].get("name") == "catboost"
+
+    def test_load_with_matching_manifest_is_clean(self) -> None:
+        predictor = self._make_predictor()
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = os.path.join(tmp, "predictor.pkl")
+            predictor.save(pkl)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                loaded = load_smartpredictor(pkl)
+            assert isinstance(loaded, type(predictor))
+
+    def test_load_without_manifest_warns_and_loads(self) -> None:
+        predictor = self._make_predictor()
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = os.path.join(tmp, "predictor.pkl")
+            save_pickle(predictor, pkl)
+            assert not os.path.exists(pkl + MANIFEST_SUFFIX)
+            with pytest.warns(DeprecationWarning, match="without a manifest sidecar"):
+                loaded = load_smartpredictor(pkl)
+            assert isinstance(loaded, type(predictor))
+
+    def test_load_with_schema_fingerprint_mismatch_raises(self) -> None:
+        predictor = self._make_predictor()
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = os.path.join(tmp, "predictor.pkl")
+            predictor.save(pkl)
+            manifest_path = pkl + MANIFEST_SUFFIX
+            with open(manifest_path, encoding="utf-8") as f:
+                manifest = json.load(f)
+            manifest["schema_fingerprint"] = "sha256:" + "0" * 64
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                json.dump(manifest, f)
+            with pytest.raises(ValueError, match="schema fingerprint mismatch"):
+                load_smartpredictor(pkl)
+
+    def test_load_with_major_version_mismatch_raises(self) -> None:
+        predictor = self._make_predictor()
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = os.path.join(tmp, "predictor.pkl")
+            predictor.save(pkl)
+            manifest_path = pkl + MANIFEST_SUFFIX
+            with open(manifest_path, encoding="utf-8") as f:
+                manifest = json.load(f)
+            manifest["shapash_version"] = "999.0.0"
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                json.dump(manifest, f)
+            with pytest.raises(ValueError, match="Major version mismatch"):
+                load_smartpredictor(pkl)
+
+    def test_load_with_minor_version_mismatch_warns(self) -> None:
+        from shapash.__version__ import VERSION
+
+        predictor = self._make_predictor()
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = os.path.join(tmp, "predictor.pkl")
+            predictor.save(pkl)
+            manifest_path = pkl + MANIFEST_SUFFIX
+            with open(manifest_path, encoding="utf-8") as f:
+                manifest = json.load(f)
+            manifest["shapash_version"] = f"{VERSION[0]}.{VERSION[1] + 1}.0"
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                json.dump(manifest, f)
+            with pytest.warns(UserWarning, match="Minor version skew"):
+                load_smartpredictor(pkl)
+
+    def test_schema_fingerprint_is_deterministic(self) -> None:
+        predictor = self._make_predictor()
+        fp1 = _compute_schema_fingerprint(predictor)
+        fp2 = _compute_schema_fingerprint(predictor)
+        assert fp1 == fp2
+        assert fp1.startswith("sha256:")
+        assert len(fp1) == len("sha256:") + 64
+
+    def test_manifest_round_trip_preserves_fingerprint(self) -> None:
+        predictor = self._make_predictor()
+        manifest = _build_predictor_manifest(predictor)
+        recomputed = _compute_schema_fingerprint(predictor)
+        assert manifest["schema_fingerprint"] == recomputed


### PR DESCRIPTION
# Description

This PR implements Gap 1 of #707 (Gap 2 shipped via PR #711, merged 2026-06-15).

`SmartPredictor.save(path)` now writes a manifest sidecar at `path + ".manifest.json"` alongside the pickle, containing:

- `shapash_version`, `python_version`
- `model_framework` (`{name, version}` — recognises scikit-learn, xgboost, lightgbm, catboost)
- `shap_version`
- `schema_fingerprint` — deterministic SHA-256 over the canonical JSON of `features_dict`, `features_types`, `columns_dict`, and `label_dict`
- `saved_at` (UTC ISO timestamp)

`load_smartpredictor(path)` uses the sidecar to detect version skew and schema tampering at load time:

| Condition | Behaviour |
|---|---|
| Manifest present and matching | Silent load |
| Manifest absent (older pickle) | `DeprecationWarning`, still loads |
| Schema fingerprint mismatch | `ValueError` (catches tampering or stale manifest) |
| Major shapash version mismatch | `ValueError` |
| Minor shapash version skew | `UserWarning` |
| Model framework version differs | `UserWarning` |

The pickle file format is unchanged — pickles saved by older versions of shapash without a manifest still load successfully (with `DeprecationWarning`).

All new helpers (`_build_predictor_manifest`, `_save_manifest`, `_load_manifest`, `_check_predictor_manifest`, `_compute_schema_fingerprint`, `_detect_model_framework`, `_try_package_version`, `_parse_major_minor`) live in `shapash/utils/io.py` next to the existing `save_pickle` / `load_pickle`. Type hints on all of them per @guillaume-vignal's mypy-prep request landed on #711.

Fixes #707 (Gap 1 of two; Gap 2 shipped via PR #711).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

8 new tests in `tests/unit_tests/utils/test_load_smartpredictor.py`:

- [x] `test_save_writes_manifest_sidecar` — `save()` writes a sidecar with all expected fields, including `model_framework.name == "catboost"`.
- [x] `test_load_with_matching_manifest_is_clean` — `load_smartpredictor` on a freshly-saved predictor produces no warning (`warnings.simplefilter("error")` guard).
- [x] `test_load_without_manifest_warns_and_loads` — `save_pickle` directly (no sidecar) followed by `load_smartpredictor` emits `DeprecationWarning` and still returns the predictor.
- [x] `test_load_with_schema_fingerprint_mismatch_raises` — tampering with the manifest's `schema_fingerprint` raises `ValueError`.
- [x] `test_load_with_major_version_mismatch_raises` — rewriting `shapash_version` to `999.0.0` raises `ValueError`.
- [x] `test_load_with_minor_version_mismatch_warns` — rewriting `shapash_version` to `X.(Y+1).0` emits `UserWarning`.
- [x] `test_schema_fingerprint_is_deterministic` — same predictor yields the same fingerprint across calls.
- [x] `test_manifest_round_trip_preserves_fingerprint` — `_build_predictor_manifest`'s fingerprint matches `_compute_schema_fingerprint` directly.

Existing `test_save_1` in `test_smart_predictor.py` updated to also clean up the new manifest sidecar after the test.

Reproduce locally:

```bash
.venv/bin/python -m pytest tests/unit_tests/explainer/test_smart_predictor.py tests/unit_tests/utils/test_load_smartpredictor.py -q
# → 45 passed (37 SmartPredictor + 1 existing roundtrip + 8 new manifest tests, minus a test-class restructure)

.venv/bin/ruff format --check shapash/utils/io.py shapash/utils/load_smartpredictor.py shapash/explainer/smart_predictor.py tests/unit_tests/utils/test_load_smartpredictor.py
# → 4 files already formatted
```

**Test Configuration**:
* OS: macOS (Darwin)
* Python version: 3.12.13
* Shapash version: 2.9.0 (editable install of this branch off master `0c34c86`)

Other library versions: pandas 3.0.3, numpy 2.4.4, catboost 1.2.10, pytest 9.0.3.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard to understand areas — docstrings on all new helpers explain the contract; the manifest schema is also documented in this PR description
- [x] I have made corresponding changes to the documentation — docstrings on `SmartPredictor.save` and `load_smartpredictor` updated to describe the sidecar; Sphinx docs auto-generate from docstrings
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules — N/A, no dependent changes

## Notes

- **Sidecar JSON vs predictor attribute.** Original issue (#707) flagged this as an open shape question. Went with sidecar JSON (the original recommendation) because it keeps the pickle bytes byte-identical to the pre-PR format, lets external tools inspect provenance without unpickling, and avoids changing the public attribute surface of `SmartPredictor`. Happy to switch to attribute-based storage if that fits your roadmap better.
- **Backward compatibility:** pickles saved by older versions of shapash (no manifest) still load — they just emit a `DeprecationWarning`. The warning category can be changed to `UserWarning` if `DeprecationWarning` is too strong a signal here.
- **The `schema_fingerprint` is computed over the user-declared schema** (`features_dict`, `features_types`, `columns_dict`, `label_dict`), not over the model or training data. Catches the case where the schema is mutated in-place after saving (which would silently break downstream `add_input` validation); doesn't attempt to claim model reproducibility — that's a different scope.
- **No new dependencies.** Uses stdlib `hashlib`, `json`, `datetime`, `importlib.metadata`.
- **Future follow-ups** (for the SmartPredictor production-hardening series): structured logging on `predict_proba` / `compute_contributions` / `summarize` failures; schema-drift detection that compares incoming distributions to the saved schema at `add_input` time. Happy to file these as separate issues if there's interest.
