### PR TITLE
Correction of bug on threshold slider and bug on clustering display

### DIFF
--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -2227,7 +2227,7 @@ class SmartPlotter:
                 dfs = [y_proba_target, y_pred, pd.Series(self.cluster_labels)]
                 cols = ["proba_values", "predict_class", "cluster"]
 
-                # --- Add target only if available
+                # --- Add target and error only if available
                 if hasattr(self._explainer, "y_target") and self._explainer.y_target is not None:
                     y_target = self._explainer.y_target.loc[list_ind].reset_index(drop=True)
                     if self._explainer.label_dict is not None:
@@ -2235,14 +2235,14 @@ class SmartPlotter:
                     dfs.append(y_target)
                     cols.append("target")
 
-                errors_classification = pd.DataFrame(
-                    np.abs(
-                        ((self._explainer.y_target.loc[list_ind].values.ravel() == label_code).astype(int))
-                        - self._explainer.proba_values.loc[list_ind].iloc[:, label_num]
+                    errors_classification = pd.DataFrame(
+                        np.abs(
+                            ((self._explainer.y_target.loc[list_ind].values.ravel() == label_code).astype(int))
+                            - self._explainer.proba_values.loc[list_ind].iloc[:, label_num]
+                        )
                     )
-                )
-                dfs.append(errors_classification.reset_index(drop=True))
-                cols.append("error")
+                    dfs.append(errors_classification.reset_index(drop=True))
+                    cols.append("error")
 
                 col_name = list(set(color_value) - {"predictions", "targets", "errors"})
                 if len(col_name) > 0:

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -122,13 +122,13 @@ class SmartApp:
         if self.explainer._case == "classification":
             self.label = self.explainer.check_label_name(len(self.explainer._classes) - 1, "num")[1]
             self.selected_feature = self.explainer.features_imp[-1].idxmax()
-            self.max_threshold = int(
-                max([x.map(lambda x: round_to_k(x, k=1)).max().max() for x in self.explainer.contributions])
+            self.max_threshold = max(
+                [x.map(lambda x: round_to_k(x, k=1)).max().max() for x in self.explainer.contributions]
             )
         else:
             self.label = None
             self.selected_feature = self.explainer.features_imp.idxmax()
-            self.max_threshold = int(self.explainer.contributions.map(lambda x: round_to_k(x, k=1)).max().max())
+            self.max_threshold = self.explainer.contributions.map(lambda x: round_to_k(x, k=1)).max().max()
         self.list_index = []
         self.subset = None
         self.last_click_data = None
@@ -697,9 +697,11 @@ class SmartApp:
                     min=0,
                     max=self.max_threshold,
                     value=0,
-                    step=0.1,
+                    step=round_to_k(self.max_threshold / 20, k=1),
                     marks={
-                        f"{round(self.max_threshold * mark / 4)}": f"{round(self.max_threshold * mark / 4)}"
+                        round_to_k(
+                            self.max_threshold * mark / 4, k=2
+                        ): f"{round_to_k(self.max_threshold * mark / 4, k=2)}"
                         for mark in range(5)
                     },
                     id="threshold_id",


### PR DESCRIPTION
# Description

## `shapash/webapp/smart_app.py`

The bug: Threshold slider on the right to local contribution does not work and sticks to 0 and is impossible to move it, despite that local contributions have values greater than 0.

<img width="2059" height="830" alt="Capture d’écran du 2026-06-16 14-48-55" src="https://github.com/user-attachments/assets/b67b123d-00ac-4abd-9b92-ddc178dd7e51" />

The fix:

- In the definition of `max_threshold` we removed `int()` cast on both classification and regression paths, contributions for probability-output classifiers (like on Titanic dataset) are small < 1, so `int(max(...))` was truncating them to 0, letting the slider inoperable with `min=0, max=0`.
- Slider step: now `round_to_k(max_threshold / 20, k=1)` scales correctly for both tiny floats (Titanic ~0.01–0.02) and large regression values (House Prices ~200)
- Slider marks: keys/labels now use `round_to_k(..., k=2)` floats instead of `round(...)` integers, so the tick labels are readable at any scale

## `shapash/explainer/smart_plotter.py`

The bug: when `y_target is None`, for example when we don't pass  `y_target` to `compile()`, we had `AttributeError: 'NoneType' object has no attribute 'loc'` affecting correct clustering computation (no clustering display in the web app).
In this fix we wrap the `errors_classification` block with the same `y_target` null-check that already guards the `target` column a few lines above. , the `error` column is simply omitted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All tests pass with `pytest`.

Manual check on the following code generating the web app on the Titanic dataset:

```
import pandas as pd
from category_encoders import OrdinalEncoder
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import train_test_split
from shapash.data.data_loader import data_loading
from shapash import SmartExplainer


if __name__ == "__main__":
    titan_df, titan_dict = data_loading('titanic')
    del titan_df['Name']
    
    y = titan_df['Survived']
    X = titan_df.drop('Survived', axis=1)

    varcat=['Pclass', 'Sex', 'Embarked', 'Title']

    categ_encoding = OrdinalEncoder(cols=varcat, \
                                handle_unknown='ignore', \
                                return_df=True).fit(X)
    X = categ_encoding.transform(X)

    Xtrain, Xtest, ytrain, ytest = train_test_split(X, y, train_size=0.75, random_state=1)

    rf = RandomForestClassifier(n_estimators=100, min_samples_leaf=3)
    rf.fit(Xtrain, ytrain)

    ypred=pd.DataFrame(rf.predict(Xtest), columns=['pred'], index=Xtest.index)

    feature_dict = {
        'Pclass': 'Ticket class',
        'Sex': 'Sex',
        'Age': 'Age',
        'SibSp': 'Relatives such as brother or wife',
        'Parch': 'Relatives like children or parents',
        'Fare': 'Passenger fare',
        'Embarked': 'Port of embarkation',
        'Title': 'Title of passenger'
    }
    label_dict = {0: "Not Survived", 1: "Survived"}
    postprocessing = {"Pclass": {'type': 'transcoding', 'rule': { 'First class': '1st class', 'Second class': '2nd class', "Third class": "3rd class"}}}

    xpl = SmartExplainer(
        model=rf,
        preprocessing=categ_encoding,
        postprocessing=postprocessing,
        label_dict=label_dict, 
        features_dict=feature_dict
    )
    xpl.compile(x=Xtest, y_pred=ypred, y_target=ytest)

    app = xpl.run_app(title_story='Titanic Survival', port=8020)
```

**Test Configuration**:
* OS: Linux
* Python version: 3.12
* Shapash version: 2.9.0