### PR TITLE
Fix LIME multiclass contributions and subset handling

### DIFF
--- a/shapash/backend/base_backend.py
+++ b/shapash/backend/base_backend.py
@@ -102,7 +102,10 @@ class BaseBackend(ABC):
 
         local_contributions = explain_data["contributions"]
         if subset is not None:
-            local_contributions = local_contributions.loc[subset]
+            if isinstance(local_contributions, list):
+                local_contributions = [c[subset] for c in local_contributions]
+            else:
+                local_contributions = local_contributions.loc[subset]
         local_contributions = self.format_and_aggregate_local_contributions(x, local_contributions)
         return local_contributions
 

--- a/shapash/backend/lime_backend.py
+++ b/shapash/backend/lime_backend.py
@@ -39,39 +39,50 @@ class LimeBackend(BaseBackend):
         data = self.data if self.data is not None else x
         explainer = lime_tabular.LimeTabularExplainer(data.values, feature_names=x.columns, mode=self._case)
 
+        def _with_feature_names(values, predict_fn):
+            if isinstance(values, pd.DataFrame):
+                return predict_fn(values)
+            try:
+                return predict_fn(pd.DataFrame(values, columns=x.columns))
+            except (TypeError, ValueError):
+                return predict_fn(values)
+
         lime_contrib = []
+        if self._case == "classification":
+            num_classes = len(self._classes)
+            if num_classes > 2:
+                contribution = []
+                for j in range(num_classes):
+                    list_contrib = []
+                    for idx in x.index:
+                        exp = explainer.explain_instance(
+                            x.loc[idx].to_numpy(),
+                            lambda values: _with_feature_names(values, self.model.predict_proba),
+                            top_labels=num_classes,
+                            num_features=x.shape[1],
+                        )
+                        list_contrib.append(
+                            {_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list(j)}
+                        )
+                    df_contrib = pd.DataFrame(list_contrib)
+                    df_contrib = df_contrib[list(x.columns)]
+                    contribution.append(df_contrib.values)
+                return dict(contributions=contribution)
+
         for i in x.index:
             if self._case == "classification":
-                num_classes = len(self._classes)
-
-                if num_classes <= 2:
-                    exp = explainer.explain_instance(
-                        x.loc[i].to_numpy(), self.model.predict_proba, num_features=x.shape[1]
-                    )
-                    lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
-
-                elif num_classes > 2:
-                    contribution = []
-                    for j in range(num_classes):
-                        list_contrib = []
-                        df_contrib = pd.DataFrame()
-                        for idx in x.index:
-                            exp = explainer.explain_instance(
-                                x.loc[idx].to_numpy(),
-                                self.model.predict_proba,
-                                top_labels=num_classes,
-                                num_features=x.shape[1],
-                            )
-                            list_contrib.append(
-                                {_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list(j)}
-                            )
-                            df_contrib = pd.DataFrame(list_contrib)
-                            df_contrib = df_contrib[list(x.columns)]
-                        contribution.append(df_contrib.values)
-                    return contribution
-
+                exp = explainer.explain_instance(
+                    x.loc[i].to_numpy(),
+                    lambda values: _with_feature_names(values, self.model.predict_proba),
+                    num_features=x.shape[1],
+                )
+                lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
             else:
-                exp = explainer.explain_instance(x.loc[i].to_numpy(), self.model.predict, num_features=x.shape[1])
+                exp = explainer.explain_instance(
+                    x.loc[i].to_numpy(),
+                    lambda values: _with_feature_names(values, self.model.predict),
+                    num_features=x.shape[1],
+                )
                 lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
 
         contributions = pd.DataFrame(lime_contrib, index=x.index)

--- a/shapash/backend/lime_backend.py
+++ b/shapash/backend/lime_backend.py
@@ -37,13 +37,14 @@ class LimeBackend(BaseBackend):
             dict containing local contributions
         """
         data = self.data if self.data is not None else x
-        explainer = lime_tabular.LimeTabularExplainer(data.values, feature_names=x.columns, mode=self._case)
+        feature_names = list(x.columns)
+        explainer = lime_tabular.LimeTabularExplainer(data.values, feature_names=feature_names, mode=self._case)
 
         def _with_feature_names(values, predict_fn):
             if isinstance(values, pd.DataFrame):
                 return predict_fn(values)
             try:
-                return predict_fn(pd.DataFrame(values, columns=x.columns))
+                return predict_fn(pd.DataFrame(values, columns=feature_names))
             except (TypeError, ValueError):
                 return predict_fn(values)
 
@@ -51,22 +52,19 @@ class LimeBackend(BaseBackend):
         if self._case == "classification":
             num_classes = len(self._classes)
             if num_classes > 2:
-                contribution = []
-                for j in range(num_classes):
-                    list_contrib = []
-                    for idx in x.index:
-                        exp = explainer.explain_instance(
-                            x.loc[idx].to_numpy(),
-                            lambda values: _with_feature_names(values, self.model.predict_proba),
-                            top_labels=num_classes,
-                            num_features=x.shape[1],
-                        )
-                        list_contrib.append(
+                contribution = [[] for _ in range(num_classes)]
+                for idx in x.index:
+                    exp = explainer.explain_instance(
+                        x.loc[idx].to_numpy(),
+                        lambda values: _with_feature_names(values, self.model.predict_proba),
+                        top_labels=num_classes,
+                        num_features=x.shape[1],
+                    )
+                    for j in range(num_classes):
+                        contribution[j].append(
                             {_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list(j)}
                         )
-                    df_contrib = pd.DataFrame(list_contrib)
-                    df_contrib = df_contrib[list(x.columns)]
-                    contribution.append(df_contrib.values)
+                contribution = [pd.DataFrame(class_contrib)[list(x.columns)].values for class_contrib in contribution]
                 return dict(contributions=contribution)
 
         for i in x.index:
@@ -88,7 +86,7 @@ class LimeBackend(BaseBackend):
         contributions = pd.DataFrame(lime_contrib, index=x.index)
         contributions = contributions[list(x.columns)]
 
-        explain_data = dict(contributions=contributions)
+        explain_data = dict(contributions=contributions.values)
 
         return explain_data
 

--- a/shapash/backend/lime_backend.py
+++ b/shapash/backend/lime_backend.py
@@ -10,6 +10,51 @@ import pandas as pd
 from shapash.backend.base_backend import BaseBackend
 
 
+def _with_feature_names(values, predict_fn, feature_names: list):
+    """
+    Wraps a predict function to ensure feature names are passed when possible.
+
+    Parameters
+    ----------
+    values : array-like or pd.DataFrame
+    predict_fn : callable
+    feature_names : list
+        Explicit column names — no implicit closure over outer scope.
+    """
+    if isinstance(values, pd.DataFrame):
+        return predict_fn(values)
+    try:
+        return predict_fn(pd.DataFrame(values, columns=feature_names))
+    except (TypeError, ValueError):
+        return predict_fn(values)
+
+
+def _transform_name(var_name: str, x_df: pd.DataFrame) -> str:
+    """Transform a LIME contribution feature string to a comprehensive column name.
+
+    Parameters
+    ----------
+    var_name : str
+        Feature name returned by LIME, often containing additional formatting.
+    x_df : pd.DataFrame
+        DataFrame used to match the LIME feature string against actual columns.
+
+    Returns
+    -------
+    str
+        The matching column name from ``x_df``.
+
+    Raises
+    ------
+    ValueError
+        If no matching column name can be found.
+    """
+    for colname in x_df.columns:
+        if f" {colname} " in f" {var_name} ":
+            return colname
+    raise ValueError(f"Could not match LIME feature string {var_name!r} to any column in {list(x_df.columns)}")
+
+
 class LimeBackend(BaseBackend):
     """The Lime Backend"""
 
@@ -22,78 +67,108 @@ class LimeBackend(BaseBackend):
         self.explainer = None
         self.data = data
 
-    def run_explainer(self, x: pd.DataFrame):
+    def run_explainer(self, x: pd.DataFrame) -> dict:
         """
-        Computes local contributions using Lime explainer
+        Computes local contributions using the Lime explainer.
 
         Parameters
         ----------
         x : pd.DataFrame
-            The observations dataframe used by the model
+            The observations dataframe used by the model.
 
         Returns
         -------
-        explain_data : dict
-            dict containing local contributions
+        dict
+            A dict with key 'contributions':
+            - pd.DataFrame of shape (n_samples, n_features)
+              for binary classification or regression.
+            - List[pd.DataFrame] of length n_classes
+              for multiclass classification.
         """
-        data = self.data if self.data is not None else x
         feature_names = list(x.columns)
-        explainer = lime_tabular.LimeTabularExplainer(data.values, feature_names=feature_names, mode=self._case)
+        data = self.data if self.data is not None else x
 
-        def _with_feature_names(values, predict_fn):
-            if isinstance(values, pd.DataFrame):
-                return predict_fn(values)
-            try:
-                return predict_fn(pd.DataFrame(values, columns=feature_names))
-            except (TypeError, ValueError):
-                return predict_fn(values)
+        # added condition to reinitialise the explainer
+        # whenever the feature names differ from what it was built with
+        if self.explainer is None or self.explainer.feature_names != feature_names:
+            self.explainer = lime_tabular.LimeTabularExplainer(
+                data.to_numpy(), feature_names=feature_names, mode=self._case
+            )
 
-        lime_contrib = []
+        model_predict = self.model.predict_proba if self._case == "classification" else self.model.predict
+
+        def predict_fn(values):
+            return _with_feature_names(values, model_predict, feature_names)
+
         if self._case == "classification":
             num_classes = len(self._classes)
             if num_classes > 2:
-                contribution = [[] for _ in range(num_classes)]
-                for idx in x.index:
-                    exp = explainer.explain_instance(
-                        x.loc[idx].to_numpy(),
-                        lambda values: _with_feature_names(values, self.model.predict_proba),
-                        top_labels=num_classes,
-                        num_features=x.shape[1],
-                    )
-                    for j in range(num_classes):
-                        contribution[j].append(
-                            {_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list(j)}
-                        )
-                contribution = [pd.DataFrame(class_contrib)[list(x.columns)].values for class_contrib in contribution]
-                return dict(contributions=contribution)
-
-        for i in x.index:
-            if self._case == "classification":
-                exp = explainer.explain_instance(
-                    x.loc[i].to_numpy(),
-                    lambda values: _with_feature_names(values, self.model.predict_proba),
-                    num_features=x.shape[1],
-                )
-                lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
+                contributions = self._explain_multiclass(x, feature_names, predict_fn, num_classes)
             else:
-                exp = explainer.explain_instance(
-                    x.loc[i].to_numpy(),
-                    lambda values: _with_feature_names(values, self.model.predict),
-                    num_features=x.shape[1],
-                )
-                lime_contrib.append({_transform_name(var_name[0], x): var_name[1] for var_name in exp.as_list()})
+                contributions = self._explain_binary_or_regression(x, feature_names, predict_fn)
+        else:
+            contributions = self._explain_binary_or_regression(x, feature_names, predict_fn)
 
-        contributions = pd.DataFrame(lime_contrib, index=x.index)
-        contributions = contributions[list(x.columns)]
+        return dict(contributions=contributions)
 
-        explain_data = dict(contributions=contributions.values)
+    def _explain_multiclass(
+        self,
+        x: pd.DataFrame,
+        feature_names: list,
+        predict_fn: callable,
+        num_classes: int,
+    ) -> list[pd.DataFrame]:
+        """
+        Compute LIME contributions for multiclass classification.
 
-        return explain_data
+        explain_instance is called once per sample; with top_labels=num_classes
+        it returns explanations for every class in a single call, so there is
+        no need to loop over classes in the outer dimension.
 
+        Returns
+        -------
+        list[pd.DataFrame]
+            One DataFrame of shape (n_samples, n_features) per class.
+        """
+        # One explain_instance call per sample — O(n_samples)
+        explanations = []
+        for idx in x.index:
+            exp = self.explainer.explain_instance(
+                x.loc[idx].to_numpy(),
+                predict_fn,
+                top_labels=num_classes,
+                num_features=x.shape[1],
+            )
+            explanations.append(exp)
 
-def _transform_name(var_name, x_df):
-    """Function for transform name of LIME contribution shape to a comprehensive name"""
-    for colname in list(x_df.columns):
-        if f" {colname} " in f" {var_name} ":
-            col_rename = colname
-    return col_rename
+        contribution = []
+        for j in range(num_classes):
+            class_contrib = [{_transform_name(feat, x): val for feat, val in exp.as_list(j)} for exp in explanations]
+            contribution.append(pd.DataFrame(class_contrib, index=x.index)[feature_names])
+
+        return contribution
+
+    def _explain_binary_or_regression(
+        self,
+        x: pd.DataFrame,
+        feature_names: list,
+        predict_fn: callable,
+    ) -> pd.DataFrame:
+        """
+        Compute LIME contributions for binary classification or regression.
+
+        Returns
+        -------
+        pd.DataFrame
+            Contributions of shape (n_samples, n_features).
+        """
+        lime_contrib = []
+        for i in x.index:
+            exp = self.explainer.explain_instance(
+                x.loc[i].to_numpy(),
+                predict_fn,
+                num_features=x.shape[1],
+            )
+            lime_contrib.append({_transform_name(feat, x): val for feat, val in exp.as_list()})
+
+        return pd.DataFrame(lime_contrib, index=x.index)[feature_names]

--- a/shapash/plots/plot_correlations.py
+++ b/shapash/plots/plot_correlations.py
@@ -155,6 +155,8 @@ def plot_correlations(
 
     if features_to_hide is None:
         features_to_hide = []
+    else:
+        features_to_hide = list(features_to_hide)
 
     if optimized:
         categorical_columns = df.select_dtypes(include=["object", "category"]).columns
@@ -167,7 +169,8 @@ def plot_correlations(
             df = df.sample(n=10000, random_state=1)
 
     if facet_col:
-        features_to_hide += [facet_col]
+        if facet_col not in features_to_hide:
+            features_to_hide.append(facet_col)
 
     compute_method = how
 

--- a/shapash/plots/plot_correlations.py
+++ b/shapash/plots/plot_correlations.py
@@ -4,6 +4,7 @@ import scipy.cluster.hierarchy as sch
 from plotly import graph_objs as go
 from plotly.offline import plot
 from plotly.subplots import make_subplots
+from scipy.spatial.distance import pdist
 
 from shapash.manipulation.summarize import compute_corr
 from shapash.style.style_utils import define_style, get_palette
@@ -97,9 +98,8 @@ def plot_correlations(
 
         if corr.shape[0] < 2:
             return corr
-
         # Compute pairwise distances based on transformed correlation matrix
-        pairwise_distances = sch.distance.pdist(np.abs(corr) ** degree)
+        pairwise_distances = pdist(np.abs(corr) ** degree)
 
         # Replace non-finite values (NaN, inf) with the maximum valid distance or 0 if all are invalid
         finite_mask = np.isfinite(pairwise_distances)

--- a/tests/unit_tests/backend/test_base_backend.py
+++ b/tests/unit_tests/backend/test_base_backend.py
@@ -49,6 +49,29 @@ class TestBaseBackend(unittest.TestCase):
         res = self.test_backend.get_local_contributions(pd.DataFrame([0]), dict(contributions=[np.array([0])]))
         assert res == [0, 4]
 
+    @patch("shapash.backend.base_backend.BaseBackend.format_and_aggregate_local_contributions")
+    def test_get_local_contributions_with_subset_on_list(self, mock_format_contrib):
+        contributions = [
+            np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+            np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]),
+        ]
+
+        def _identity(_x, local_contrib):
+            return local_contrib
+
+        mock_format_contrib.side_effect = _identity
+
+        res = self.test_backend.get_local_contributions(
+            pd.DataFrame([[0, 0], [1, 1], [2, 2]]),
+            dict(contributions=contributions),
+            subset=[0, 2],
+        )
+
+        assert isinstance(res, list)
+        assert len(res) == 2
+        np.testing.assert_array_equal(res[0], np.array([[1.0, 2.0], [5.0, 6.0]]))
+        np.testing.assert_array_equal(res[1], np.array([[10.0, 20.0], [50.0, 60.0]]))
+
     def test_get_local_contributions_2(self):
         """
         Explain data should be a dict

--- a/tests/unit_tests/backend/test_lime_backend.py
+++ b/tests/unit_tests/backend/test_lime_backend.py
@@ -67,3 +67,37 @@ class TestLimeBackend(unittest.TestCase):
                 assert len(features_imp[0]) == len(self.x_df.columns)
             else:
                 assert len(features_imp) == len(self.x_df.columns)
+
+    def test_run_explainer_multiclass_returns_list_contributions(self):
+        """Test multiclass (>2) branch returns a list-like contributions payload."""
+        x_multi = pd.DataFrame(
+            {
+                "x1": [10, 11, 20, 21, 30, 31],
+                "x2": [1, 2, 1, 2, 1, 2],
+            },
+            index=[0, 1, 2, 3, 4, 5],
+        )
+        y_multi = pd.Series([0, 0, 1, 1, 2, 2], index=x_multi.index)
+
+        model = ske.RandomForestClassifier(n_estimators=5, random_state=42)
+        model.fit(x_multi.values, y_multi)
+
+        backend_xpl = LimeBackend(model, data=x_multi)
+        explain_data = backend_xpl.run_explainer(x_multi)
+
+        assert isinstance(explain_data, dict)
+        assert "contributions" in explain_data
+
+        contributions = explain_data["contributions"]
+        assert isinstance(contributions, list)
+        assert len(contributions) == 3
+        for class_contrib in contributions:
+            assert isinstance(class_contrib, np.ndarray)
+            assert class_contrib.shape == (len(x_multi), x_multi.shape[1])
+
+        local_contrib = backend_xpl.get_local_contributions(x_multi, explain_data)
+        assert isinstance(local_contrib, list)
+        assert len(local_contrib) == 3
+        for class_contrib_df in local_contrib:
+            assert isinstance(class_contrib_df, pd.DataFrame)
+            assert class_contrib_df.shape == (len(x_multi), x_multi.shape[1])

--- a/tests/unit_tests/backend/test_lime_backend.py
+++ b/tests/unit_tests/backend/test_lime_backend.py
@@ -92,7 +92,7 @@ class TestLimeBackend(unittest.TestCase):
         assert isinstance(contributions, list)
         assert len(contributions) == 3
         for class_contrib in contributions:
-            assert isinstance(class_contrib, np.ndarray)
+            assert isinstance(class_contrib, pd.DataFrame)
             assert class_contrib.shape == (len(x_multi), x_multi.shape[1])
 
         local_contrib = backend_xpl.get_local_contributions(x_multi, explain_data)

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -2119,6 +2119,20 @@ class TestSmartPlotter(unittest.TestCase):
         assert len(output.data[0].y) == 3
         assert output.data[0].z.shape == (3, 3)
 
+    def test_correlations_does_not_mutate_features_to_hide(self):
+        smart_explainer = self.smart_explainer
+
+        df = pd.DataFrame(
+            {"A": [8, 90, 10, 110], "B": [4.3, 7.4, 10.2, 15.7], "C": ["C8", "C8", "C9", "C9"], "D": [1, -3, -5, -10]},
+            index=[8, 9, 10, 11],
+        )
+        features_to_hide = ["D"]
+
+        output = smart_explainer.plot.correlations_plot(df, max_features=3, features_to_hide=features_to_hide, facet_col="C")
+
+        assert len(output.data) == 2
+        assert features_to_hide == ["D"]
+
     def test_stability_plot_1(self):
         np.random.seed(42)
         df = pd.DataFrame(np.random.randint(0, 100, size=(50, 4)), columns=list("ABCD"))

--- a/tests/unit_tests/manipulation/test_summarize.py
+++ b/tests/unit_tests/manipulation/test_summarize.py
@@ -2,12 +2,13 @@
 Unit test of summarize
 """
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
-from shapash.manipulation.summarize import compute_features_import, group_contributions, summarize_el
+from shapash.manipulation.summarize import compute_corr, compute_features_import, group_contributions, summarize_el
 
 
 class TestSummarize(unittest.TestCase):
@@ -124,3 +125,34 @@ class TestSummarize(unittest.TestCase):
             [[0.5, -0.02], [0.1, -0.03], [-0.6, 0.4]], columns=["group1", "group2"], index=index_list
         )
         assert_frame_equal(output, expected)
+
+
+class TestComputeCorr(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0, 5.0],
+                "b": [2.0, 4.0, 6.0, 8.0, 10.0],
+                "c": [5.0, 3.0, 1.0, 3.0, 5.0],
+            }
+        )
+
+    def test_compute_corr_pearson(self):
+        result = compute_corr(self.df, "pearson")
+        assert_frame_equal(result, self.df.corr())
+
+    def test_compute_corr_phik(self):
+        result = compute_corr(self.df, "phik")
+        assert result.shape == (len(self.df.columns), len(self.df.columns))
+        assert list(result.columns) == list(self.df.columns)
+        assert list(result.index) == list(self.df.columns)
+        assert (result.values >= 0).all() and (result.values <= 1).all()
+
+    def test_compute_corr_phik_fallback_to_pearson_when_not_installed(self):
+        with patch("shapash.manipulation.summarize.import_optional_module", return_value=None):
+            result = compute_corr(self.df, "phik")
+        assert_frame_equal(result, self.df.corr())
+
+    def test_compute_corr_unknown_method_raises(self):
+        with self.assertRaises(NotImplementedError):
+            compute_corr(self.df, "spearman")

--- a/tests/unit_tests/utils/test_transform.py
+++ b/tests/unit_tests/utils/test_transform.py
@@ -255,7 +255,7 @@ class TestInverseTransformCaterogyEncoder(unittest.TestCase):
 
         self.assertDictEqual(mapping, expected_mapping)
 
-    def handle_categorical_missing(self):
+    def test_handle_categorical_missing(self):
         """
         test handle_categorical_missing
         """


### PR DESCRIPTION
## Summary
This PR fixes LIME backend behavior for multiclass classification and aligns contribution handling with the common backend flow.

Fixes #725.

## What changed
- Handle subset selection in `BaseBackend.get_local_contributions` when contributions are list-based (multiclass case).
- Normalize multiclass LIME output to return a dictionary with a `contributions` key.
- Add a feature-name-safe wrapper around `predict` / `predict_proba` calls used by LIME.
- Add backend unit tests for multiclass contribution format and subset slicing behavior.
- Deal with dependency issue with `scipy==1.18.0` modifying import of `pdist`
- Add unit test for `compute_corr` function (testing import of optional module `phik`, which could be affected by upgrade of `scipy` version)