### PR TITLE
Limit scipy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pandas>=2.2.2,<4.0.0",
     "plotly>=5.0.0,<6.0.0",
     "scikit-learn>=1.8.0,<1.9.0",
-    "scipy>=1.13.0",
+    "scipy>=1.13.0,<1.18.0",
     "shap>=0.46.0",
     "shapely>=2.0.0",
 ]


### PR DESCRIPTION
Scipy recently released version 1.18.0 breaks some integration (report) and unit tests.

Scipy 1.18.0 dropped Python 3.11 support.
- Python < 3.12 → gets scipy 1.17.1 → test passes
- Python ≥ 3.12 → gets scipy 1.18.0 → test fails

In particular, integration test `test_report_generation.py` was failing due to a `papermill` error.
Papermill executes `base_report.ipynb`, the notebook imports indirectly `plot_correlations` which uses `phik` for correlations. Scipy 1.18.0 removed `lambda_` parameter which is used in `phik` backbone methods, with the consequence of triggering an error.

Keep in mind that a future fixing release of `phik` could affect correct behaviour as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* OS: Linux
* Python version: 3.13.13
* Shapash version: 2.9.0