### PR TITLE
Update precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,21 +27,19 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=3000']
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.15.18
     hooks:
-      - id: ruff
+      # Run the linter
+      - id: ruff-check
         args: [--fix]
+      # Run the formatter
       - id: ruff-format
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-    -   id: pyupgrade
-        args: [--py311-plus]
--   repo: https://github.com/asottile/blacken-docs
-    rev: v1.8.0
+        types_or: [python, pyi, markdown]
+-   repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.20.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==21.12b0]
+        additional_dependencies: [black==26.5.1]
 -   repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,16 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-ast
     -   id: fix-byte-order-marker
     -   id: check-case-conflict
+    -   id: check-merge-conflict
     -   id: check-docstring-first
     -   id: check-shebang-scripts-are-executable
     -   id: check-json
+    -   id: check-toml
     -   id: check-yaml
         exclude: ^chart/
     -   id: debug-statements
@@ -34,7 +36,6 @@ repos:
         args: [--fix]
       # Run the formatter
       - id: ruff-format
-        types_or: [python, pyi, markdown]
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.20.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=3000']
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.20
     hooks:
       # Run the linter
       - id: ruff-check


### PR DESCRIPTION
Updates the pre-commit hook configuration to be consistent with the project's current tooling:

- **ruff**: bump from `v0.5.2` to `v0.15.20` (aligns with the version in `uv.lock`); use the canonical ruff-check hook id instead of ruff
- **pyupgrade**: removed — redundant with ruff's UP ruleset already enabled in `pyproject.toml`
- **blacken-docs**: switch to the maintained fork (`adamchainz/blacken-docs`), bump Black dependency from `21.12b0` to `26.5.1`
- **pre-commit-hooks**: bump to `v6.0.0`; add `check-merge-conflict` and `check-toml` hooks

## Test

`pre-commit run --all-files`: all checks passed

## Type of change

- [x] Maintenance of project tooling