### PR TITLE
Cap pandas version to prevent segfault bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "nbformat>5.8.0",
     "numba>=0.60.0",
     "numpy>=2.0.0,<2.6.0",
-    "pandas>=2.2.2,<4.0.0",
+    "pandas>=2.2.2,<3.0.4",
     "plotly>=5.0.0,<6.0.0",
     "scikit-learn>=1.8.0,<1.9.0",
     "scipy>=1.13.0",


### PR DESCRIPTION
# Description

The recent upgrade to `pandas==3.0.4` generates a [bug](https://github.com/pandas-dev/pandas/issues/66083).
The bug documents that `3.0.4` runs fine on `numpy 2.5.0` but segfaults on numpy `2.3.5` and `2.4.6`.
In our settings, `numpy` sticks to `2.4.6` since another dependency `numba` declares to be dependent on `numpy<2.5`.
Then, as a temporary solution, we cap pandas to have max version `3.0.3`.