### PR TITLE
fix: make run_app kill() actually stop the server

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -9,6 +9,7 @@ import tempfile
 
 import numpy as np
 import pandas as pd
+from werkzeug.serving import make_server
 
 import shapash.explainer.smart_predictor
 from shapash.backend import BaseBackend, get_backend_cls_from_name
@@ -1500,7 +1501,14 @@ class SmartExplainer:
             if port is None:
                 port = 8050
             host_name = get_host_name()
-            server_instance = CustomThread(target=lambda: self.smartapp.app.run(debug=False, host=host, port=port))
+            wsgi_server = make_server(host, port, self.smartapp.server)
+            server_instance = CustomThread(target=wsgi_server.serve_forever)
+
+            def _kill():
+                wsgi_server.shutdown()
+                server_instance.killed = True
+
+            server_instance.kill = _kill
             if host_name is None:
                 host_name = host
             elif host != DEFAULT_HOST:

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -1077,8 +1077,9 @@ class TestSmartExplainer(unittest.TestCase):
 
     @patch("shapash.explainer.smart_explainer.SmartApp")
     @patch("shapash.explainer.smart_explainer.CustomThread")
+    @patch("shapash.explainer.smart_explainer.make_server")
     @patch("shapash.explainer.smart_explainer.get_host_name")
-    def test_run_app_1(self, mock_get_host_name, mock_custom_thread, mock_smartapp):
+    def test_run_app_1(self, mock_get_host_name, mock_make_server, mock_custom_thread, mock_smartapp):
         """
         Test that when y_pred is not given, y_pred is automatically computed.
         """
@@ -1094,8 +1095,9 @@ class TestSmartExplainer(unittest.TestCase):
 
     @patch("shapash.explainer.smart_explainer.SmartApp")
     @patch("shapash.explainer.smart_explainer.CustomThread")
+    @patch("shapash.explainer.smart_explainer.make_server")
     @patch("shapash.explainer.smart_explainer.get_host_name")
-    def test_run_app_2(self, mock_get_host_name, mock_custom_thread, mock_smartapp):
+    def test_run_app_2(self, mock_get_host_name, mock_make_server, mock_custom_thread, mock_smartapp):
         """
         Test that when y_target is given
         """


### PR DESCRIPTION
Use werkzeug `make_server` directly so `kill()` can call `wsgi_server.shutdown()`, instead of relying on `sys.settrace` which never fires while the server is blocked in C-level socket I/O.

Fixes #717 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run in notebook
```
xpl = SmartExplainer(...)
xpl.compile(...)

app = xpl.run_app()

# Stop the app
app.kill()
```
and checked that the webapp was correctly killed.

**Test Configuration**:
* OS: Linux
* Python version: 3.13.13
* Shapash version: 2.9.0