### PR TITLE
Confusion matrix color scale not adapted for imbalanced datasets

### DIFF
--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -1883,13 +1883,18 @@ class SmartPlotter:
         self,
         width: int = 700,
         height: int = 500,
-        use_quantile_scale: float | None = None,
+        color_quantile_cap: float | None = None,
         file_name=None,
         auto_open=False,
     ):
         """
         Returns a matplotlib figure containing a confusion matrix that is computed using y_true and
         y_pred parameters.
+
+        On imbalanced datasets, the dominant class can crush the color scale and
+        make the other cells look identical. Set the optional `color_quantile_cap` parameter
+        to cap the heatmap colors at that quantile and restore the
+        contrast: only the colors are affected on the other hand the displayed counts, hover and colorbar ticks keep the true values
 
         Parameters
         ----------
@@ -1903,7 +1908,7 @@ class SmartPlotter:
             The width of the generated figure, in inches.
         height : int, optional, default=4
             The height of the generated figure, in inches.
-        use_quantile_scale : float, optional, default=None
+        color_quantile_cap : float, optional, default=None
             Upper quantile used to cap the cell color, useful on
             imbalanced datasets. If None (default), the full value range is used.
 
@@ -1929,7 +1934,7 @@ class SmartPlotter:
             colors_dict=self._style_dict,
             width=width,
             height=height,
-            use_quantile_scale=use_quantile_scale,
+            color_quantile_cap=color_quantile_cap,
             file_name=file_name,
             auto_open=auto_open,
         )

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -1883,8 +1883,7 @@ class SmartPlotter:
         self,
         width: int = 700,
         height: int = 500,
-        use_quantile_scale: bool = False,
-        quantile: float | None = None,
+        use_quantile_scale: float | None = None,
         file_name=None,
         auto_open=False,
     ):
@@ -1904,11 +1903,9 @@ class SmartPlotter:
             The width of the generated figure, in inches.
         height : int, optional, default=4
             The height of the generated figure, in inches.
-        use_quantile_scale : bool, optional, default=False
-            If True, the color scale of the confusion matrix will be based on quantiles of the
-            confusion matrix values. If False, the color scale will be based on the actual values.
-        quantile : float, optional, default=None
-            If use_quantile_scale is True, this parameter specifies the quantile to use for scaling the color scale.
+        use_quantile_scale : float, optional, default=None
+            Upper quantile used to cap the cell color, useful on
+            imbalanced datasets. If None (default), the full value range is used.
 
         Returns
         -------
@@ -1933,7 +1930,6 @@ class SmartPlotter:
             width=width,
             height=height,
             use_quantile_scale=use_quantile_scale,
-            quantile=quantile,
             file_name=file_name,
             auto_open=auto_open,
         )

--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -1883,6 +1883,8 @@ class SmartPlotter:
         self,
         width: int = 700,
         height: int = 500,
+        use_quantile_scale: bool = False,
+        quantile: float | None = None,
         file_name=None,
         auto_open=False,
     ):
@@ -1902,6 +1904,11 @@ class SmartPlotter:
             The width of the generated figure, in inches.
         height : int, optional, default=4
             The height of the generated figure, in inches.
+        use_quantile_scale : bool, optional, default=False
+            If True, the color scale of the confusion matrix will be based on quantiles of the
+            confusion matrix values. If False, the color scale will be based on the actual values.
+        quantile : float, optional, default=None
+            If use_quantile_scale is True, this parameter specifies the quantile to use for scaling the color scale.
 
         Returns
         -------
@@ -1925,6 +1932,8 @@ class SmartPlotter:
             colors_dict=self._style_dict,
             width=width,
             height=height,
+            use_quantile_scale=use_quantile_scale,
+            quantile=quantile,
             file_name=file_name,
             auto_open=auto_open,
         )

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 from plotly import graph_objs as go
@@ -506,8 +504,7 @@ def plot_confusion_matrix(
     colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
-    use_quantile_scale: bool = False,
-    quantile: float | None = None,
+    use_quantile_scale: float | None = None,
     palette_name: str = "default",
     file_name=None,
     auto_open=False,
@@ -527,10 +524,8 @@ def plot_confusion_matrix(
         The width of the figure in pixels.
     height : int, optional
         The height of the figure in pixels.
-    use_quantile_scale : bool, optional
-        Whether to use a quantile-based color scale for the heatmap.
-    quantile : float, optional
-        The quantile value to use for color scaling if `use_quantile_scale` is True.
+    use_quantile_scale : float, optional
+        Upper quantile used to cap the cell color. If None (default),the full value range is used.
     palette_name : str, optional
         The color palette to use for the heatmap.
     file_name: string, optional
@@ -598,18 +593,12 @@ def plot_confusion_matrix(
 
         # Shorten labels that exceed the threshold
         y_labels = [x.replace(x[k + k // 2 : -k + k // 2], "...") if len(x) > 2 * k + 3 else x for x in y_labels]
-    if use_quantile_scale != (quantile is not None):
-        warnings.warn(
-            "quantile and use_quantile_scale must be set together: the color scale is not capped",
-            UserWarning,
-            stacklevel=1,
-        )
     # Cap the cell colors at the given quantile: colors saturate at the cap,
     # while the colorbar ticks keep showing the true value range
     color_zmax = z.max()
     colorbar = None
-    if use_quantile_scale and quantile is not None:
-        capped_zmax = np.quantile(z, quantile)
+    if use_quantile_scale is not None:
+        capped_zmax = np.quantile(z, use_quantile_scale)
         if 0 < capped_zmax < color_zmax:
             colorbar = dict(
                 tickmode="array",

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 from plotly import graph_objs as go
@@ -504,6 +506,8 @@ def plot_confusion_matrix(
     colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
+    use_quantile_scale: bool = False,
+    quantile: float | None = None,
     palette_name: str = "default",
     file_name=None,
     auto_open=False,
@@ -523,6 +527,10 @@ def plot_confusion_matrix(
         The width of the figure in pixels.
     height : int, optional
         The height of the figure in pixels.
+    use_quantile_scale : bool, optional
+        Whether to use a quantile-based color scale for the heatmap.
+    quantile : float, optional
+        The quantile value to use for color scaling if `use_quantile_scale` is True.
     palette_name : str, optional
         The color palette to use for the heatmap.
     file_name: string, optional
@@ -590,6 +598,25 @@ def plot_confusion_matrix(
 
         # Shorten labels that exceed the threshold
         y_labels = [x.replace(x[k + k // 2 : -k + k // 2], "...") if len(x) > 2 * k + 3 else x for x in y_labels]
+    if use_quantile_scale != (quantile is not None):
+        warnings.warn(
+            "quantile and use_quantile_scale must be set together: the color scale is not capped",
+            UserWarning,
+            stacklevel=1,
+        )
+    # Cap the cell colors at the given quantile: colors saturate at the cap,
+    # while the colorbar ticks keep showing the true value range
+    color_zmax = z.max()
+    colorbar = None
+    if use_quantile_scale and quantile is not None:
+        capped_zmax = np.quantile(z, quantile)
+        if 0 < capped_zmax < color_zmax:
+            colorbar = dict(
+                tickmode="array",
+                tickvals=np.linspace(0, capped_zmax, 6),
+                ticktext=[f"{v:.0f}" for v in np.linspace(0, color_zmax, 6)],
+            )
+            color_zmax = capped_zmax
 
     # Create the heatmap using go.Heatmap
     heatmap = go.Heatmap(
@@ -597,11 +624,13 @@ def plot_confusion_matrix(
         x=x_labels,
         y=y_labels,
         colorscale=col_scale,
+        zmin=0,
+        zmax=color_zmax,
+        colorbar=colorbar,
         hovertext=hv_text,
         hovertemplate="%{hovertext}<extra></extra>",
         showscale=True,
     )
-
     fig = go.Figure(data=[heatmap])
 
     # Add annotations for each cell
@@ -614,7 +643,7 @@ def plot_confusion_matrix(
                     y=y_label,
                     text=str(z[i][j]),
                     showarrow=False,
-                    font=dict(color="black" if z[i][j] < z.max() / 2 else "white"),
+                    font=dict(color="black" if z[i][j] < color_zmax / 2 else "white"),
                 )
             )
 

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -504,7 +504,7 @@ def plot_confusion_matrix(
     colors_dict: dict | None = None,
     width: int = 700,
     height: int = 500,
-    use_quantile_scale: float | None = None,
+    color_quantile_cap: float | None = None,
     palette_name: str = "default",
     file_name=None,
     auto_open=False,
@@ -524,7 +524,7 @@ def plot_confusion_matrix(
         The width of the figure in pixels.
     height : int, optional
         The height of the figure in pixels.
-    use_quantile_scale : float, optional
+    color_quantile_cap : float, optional
         Upper quantile used to cap the cell color. If None (default),the full value range is used.
     palette_name : str, optional
         The color palette to use for the heatmap.
@@ -597,8 +597,8 @@ def plot_confusion_matrix(
     # while the colorbar ticks keep showing the true value range
     color_zmax = z.max()
     colorbar = None
-    if use_quantile_scale is not None:
-        capped_zmax = np.quantile(z, use_quantile_scale)
+    if color_quantile_cap is not None:
+        capped_zmax = np.quantile(z, color_quantile_cap)
         if 0 < capped_zmax < color_zmax:
             colorbar = dict(
                 tickmode="array",

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -2582,7 +2582,7 @@ class TestSmartPlotter(unittest.TestCase):
         xpl.compile(x=X_train, y_target=y_train)
 
         output_default = xpl.plot.confusion_matrix_plot()
-        output_capped = xpl.plot.confusion_matrix_plot(use_quantile_scale=0.95)
+        output_capped = xpl.plot.confusion_matrix_plot(color_quantile_cap=0.95)
         z = np.array(output_default.data[0].z)
 
         # colors: full range by default, saturate at the quantile when capped

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -2582,7 +2582,7 @@ class TestSmartPlotter(unittest.TestCase):
         xpl.compile(x=X_train, y_target=y_train)
 
         output_default = xpl.plot.confusion_matrix_plot()
-        output_capped = xpl.plot.confusion_matrix_plot(use_quantile_scale=True, quantile=0.95)
+        output_capped = xpl.plot.confusion_matrix_plot(use_quantile_scale=0.95)
         z = np.array(output_default.data[0].z)
 
         # colors: full range by default, saturate at the quantile when capped
@@ -2591,8 +2591,3 @@ class TestSmartPlotter(unittest.TestCase):
         # colorbar: automatic ticks by default, true values when capped
         assert output_default.data[0].colorbar.tickvals is None
         assert float(output_capped.data[0].colorbar.ticktext[-1]) == z.max()
-        # warning when use_quantile_scale and quantile are not set together
-        with self.assertWarns(UserWarning):
-            xpl.plot.confusion_matrix_plot(use_quantile_scale=True)
-        with self.assertWarns(UserWarning):
-            xpl.plot.confusion_matrix_plot(quantile=0.95)

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -2570,3 +2570,29 @@ class TestSmartPlotter(unittest.TestCase):
         assert type(output) is go.Figure
         assert len(output.data) == 1
         assert output.data[0].type == "scatter"
+
+    def test_confusion_matrix_plot(self):
+        """
+        Classification - compare default behavior and quantile capping
+        """
+        X_train = pd.DataFrame(np.random.randint(0, 100, size=(50, 3)), columns=list("ABC"))
+        y_train = pd.DataFrame(np.array([0] * 45 + [1] * 5))
+        model = DecisionTreeClassifier().fit(X_train, y_train)
+        xpl = SmartExplainer(model=model)
+        xpl.compile(x=X_train, y_target=y_train)
+
+        output_default = xpl.plot.confusion_matrix_plot()
+        output_capped = xpl.plot.confusion_matrix_plot(use_quantile_scale=True, quantile=0.95)
+        z = np.array(output_default.data[0].z)
+
+        # colors: full range by default, saturate at the quantile when capped
+        assert output_default.data[0].zmax == z.max()
+        assert output_capped.data[0].zmax == np.quantile(z, 0.95)
+        # colorbar: automatic ticks by default, true values when capped
+        assert output_default.data[0].colorbar.tickvals is None
+        assert float(output_capped.data[0].colorbar.ticktext[-1]) == z.max()
+        # warning when use_quantile_scale and quantile are not set together
+        with self.assertWarns(UserWarning):
+            xpl.plot.confusion_matrix_plot(use_quantile_scale=True)
+        with self.assertWarns(UserWarning):
+            xpl.plot.confusion_matrix_plot(quantile=0.95)


### PR DESCRIPTION
Fixes #685 

On imbalanced datasets, the confusion matrix becomes unreadable -> the majority class
crushes the color scale and all the other cells look the same.

This PR introduces an optional quantile-based capping of the color scale. Colors
saturate at the chosen quantile, restoring contrast for the smaller cells, while the
actual values remain visible everywhere : in the cells, the hover, and the colorbar
ticks. 
**Only the coloring of the cells that changes**

## The new parameter:
- **`color_quantile_cap`** (`float`, default `None`) : the capping level to be chosen by the
  user (no default value). For example, passing `quantile=0.95` draws any cell above the 95th percentile of the matrix values with the maximum color, otherwise the full range is used 

## Checklist
- [x]  Colors capped at the quantile
- [x]  Colorbar ticks show the true value range (0 → actual max), not the capped one
- [x]  Counts, annotations and hover untouched
- [x] Unit test: both behaviors

## Example

```python
xpl.plot.confusion_matrix_plot(color_quantile_cap=0.95) 
```

- Here is the actual behaviour:

<img width="638" height="463" alt="Screenshot 2026-07-07 at 00 19 46" src="https://github.com/user-attachments/assets/77b7a547-5aa2-4246-b212-6b6b6b6bf675" />
