### PR TITLE
Confusion matrix misinterprets integer class labels as continuous range #684

### DIFF
--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -558,9 +558,10 @@ def plot_confusion_matrix(
     col_scale = [(value, color) for value, color in zip(linspace, init_colorscale, strict=False)]
 
     # Convert the DataFrame to a NumPy array
-    x_labels = list(df_cm.columns)
-    y_labels = list(df_cm.index)
-    z = df_cm.loc[x_labels, y_labels].values
+    # Cast labels to strings so Plotly treats them as categories, not a continuous numeric range
+    x_labels = [str(label) for label in df_cm.columns]
+    y_labels = [str(label) for label in df_cm.index]
+    z = df_cm.values
 
     title = "Confusion Matrix"
     dict_t = style_dict["dict_title"] | {"text": title, "y": adjust_title_height(height)}
@@ -568,8 +569,8 @@ def plot_confusion_matrix(
     dict_yaxis = style_dict["dict_yaxis"] | {"text": se_y_true.name}
 
     # Determine if labels are numeric
-    x_numeric = all(str(label).isdigit() for label in x_labels)
-    y_numeric = all(str(label).isdigit() for label in y_labels)
+    x_numeric = all(label.isdigit() for label in x_labels)
+    y_numeric = all(label.isdigit() for label in y_labels)
 
     hv_text = [
         [f"Actual: {y}<br>Predicted: {x}<br>Count: {value}" for x, value in zip(x_labels, row, strict=False)]
@@ -622,14 +623,15 @@ def plot_confusion_matrix(
     )
     fig = go.Figure(data=[heatmap])
 
-    # Add annotations for each cell
+    # Add cell annotations positioned by index, not label: on a category axis a
+    # numeric looking label could be read as a position and land off-grid
     annotations = []
-    for i, y_label in enumerate(y_labels):
-        for j, x_label in enumerate(x_labels):
+    for i in range(len(y_labels)):
+        for j in range(len(x_labels)):
             annotations.append(
                 dict(
-                    x=x_label,
-                    y=y_label,
+                    x=j,
+                    y=i,
                     text=str(z[i][j]),
                     showarrow=False,
                     font=dict(color="black" if z[i][j] < color_zmax / 2 else "white"),
@@ -643,15 +645,17 @@ def plot_confusion_matrix(
         xaxis=dict(
             title=dict_xaxis,
             tickangle=45,
+            type="category",
             tickmode="array" if x_numeric else "linear",
-            tickvals=[int(label) for label in x_labels] if x_numeric else None,
+            tickvals=x_labels if x_numeric else None,
             ticktext=x_labels if x_numeric else None,
         ),
         yaxis=dict(
             title=dict_yaxis,
             autorange="reversed",  # Reverse y-axis to match conventional confusion matrix
+            type="category",  # force a categorical axis, so labels aren't read as numbers
             tickmode="array" if y_numeric else "linear",
-            tickvals=[int(label) for label in y_labels] if y_numeric else None,
+            tickvals=y_labels if y_numeric else None,
             ticktext=y_labels if y_numeric else None,
         ),
         width=width,

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -645,17 +645,15 @@ def plot_confusion_matrix(
         xaxis=dict(
             title=dict_xaxis,
             tickangle=45,
-            type="category",
             tickmode="array" if x_numeric else "linear",
-            tickvals=x_labels if x_numeric else None,
+            tickvals=[int(label) for label in x_labels] if x_numeric else None,
             ticktext=x_labels if x_numeric else None,
         ),
         yaxis=dict(
             title=dict_yaxis,
             autorange="reversed",  # Reverse y-axis to match conventional confusion matrix
-            type="category",  # force a categorical axis, so labels aren't read as numbers
             tickmode="array" if y_numeric else "linear",
-            tickvals=y_labels if y_numeric else None,
+            tickvals=[int(label) for label in y_labels] if y_numeric else None,
             ticktext=y_labels if y_numeric else None,
         ),
         width=width,

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -2602,10 +2602,10 @@ class TestSmartPlotter(unittest.TestCase):
         assert output.data[0].x == ("1", "2", "10")
         assert output.data[0].y == ("1", "2", "10")
         assert np.array(output.data[0].z).tolist() == [[1, 1, 0], [0, 1, 1], [1, 0, 1]]
-        assert output.layout.xaxis.type == "category"
-        assert output.layout.yaxis.type == "category"
-        assert output.layout.xaxis.tickvals == ("1", "2", "10")
-        assert output.layout.yaxis.tickvals == ("1", "2", "10")
+        assert output.layout.xaxis.tickvals == (1, 2, 10)
+        assert output.layout.yaxis.tickvals == (1, 2, 10)
+        assert output.layout.xaxis.ticktext == ("1", "2", "10")
+        assert output.layout.yaxis.ticktext == ("1", "2", "10")
 
         assert {annotation.x for annotation in output.layout.annotations} == {0, 1, 2}
         assert {annotation.y for annotation in output.layout.annotations} == {0, 1, 2}
@@ -2613,4 +2613,4 @@ class TestSmartPlotter(unittest.TestCase):
         # for the text labels
         output_str = plot_confusion_matrix(y_true=["A", "B", "C"], y_pred=["B", "B", "C"])
         assert output_str.data[0].x == ("A", "B", "C")
-        assert output_str.layout.xaxis.type == "category"
+        assert output_str.layout.xaxis.tickvals is None

--- a/tests/unit_tests/explainer/test_smart_plotter.py
+++ b/tests/unit_tests/explainer/test_smart_plotter.py
@@ -19,6 +19,7 @@ from shapash.backend import ShapBackend
 from shapash.explainer.multi_decorator import MultiDecorator
 from shapash.explainer.smart_state import SmartState
 from shapash.plots.plot_bar_chart import plot_bar_chart
+from shapash.plots.plot_evaluation_metrics import plot_confusion_matrix
 from shapash.plots.plot_feature_importance import _plot_features_import
 from shapash.plots.plot_line_comparison import plot_line_comparison
 from shapash.style.style_utils import get_palette
@@ -2591,3 +2592,25 @@ class TestSmartPlotter(unittest.TestCase):
         # colorbar: automatic ticks by default, true values when capped
         assert output_default.data[0].colorbar.tickvals is None
         assert float(output_capped.data[0].colorbar.ticktext[-1]) == z.max()
+
+    def test_confusion_matrix_plot_categorical_labels(self):
+        """
+        Numeric labels are plotted as categories, not as a numeric range
+        """
+        output = plot_confusion_matrix(y_true=[1, 1, 2, 10, 10, 2], y_pred=[1, 2, 2, 10, 1, 10])
+
+        assert output.data[0].x == ("1", "2", "10")
+        assert output.data[0].y == ("1", "2", "10")
+        assert np.array(output.data[0].z).tolist() == [[1, 1, 0], [0, 1, 1], [1, 0, 1]]
+        assert output.layout.xaxis.type == "category"
+        assert output.layout.yaxis.type == "category"
+        assert output.layout.xaxis.tickvals == ("1", "2", "10")
+        assert output.layout.yaxis.tickvals == ("1", "2", "10")
+
+        assert {annotation.x for annotation in output.layout.annotations} == {0, 1, 2}
+        assert {annotation.y for annotation in output.layout.annotations} == {0, 1, 2}
+
+        # for the text labels
+        output_str = plot_confusion_matrix(y_true=["A", "B", "C"], y_pred=["B", "B", "C"])
+        assert output_str.data[0].x == ("A", "B", "C")
+        assert output_str.layout.xaxis.type == "category"


### PR DESCRIPTION
Fixes #684 

# Description

`plot_confusion_matrix` passed integer labels to Plotly, which read them as a continuous numeric axis. Classes with gaps like `[1, 2, 10]` left blank spaces in the heatmap

<img width="354" height="328" alt="Screenshot 2026-07-08 at 13 23 57" src="https://github.com/user-attachments/assets/479c90a1-a893-4d5a-9426-01bab4908441" />

# Fix :
- class labels are cast to strings when extracted from the crosstab, so the heatmap receives categorical values instead of numbers
- Cell counts are anchored by class index (`x=j, y=i`), not by label value, because Plotly
  reads a numeric looking coordinate like `"10"` as a position rather than a class name, this is why we have gap space between classes.

Here is the actual behaviour:
<img width="463" height="379" alt="Screenshot 2026-07-08 at 15 47 35" src="https://github.com/user-attachments/assets/82d5771f-3016-4435-b4a1-2c2b6e7e629a" />


# Checklist:

- [x] Verified the fix on several cases:
       - the example from the issue (integer labels `[1, 2, 10]`)
       - string labels (`["A", "B","C"]`)
       - and high number of classes (more than 20), to test if all the classes are displayed

- [x] Added a unit test for numeric/string labels

