### PR TITLE
Enable mypy type checking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
       run: make lint
     - name: Check formatting
       run: make format
+    - name: Check type annotations
+      run: make typecheck
 
   test:
     name: Build & Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,18 @@ repos:
         args: [--fix]
       # Run the formatter
       - id: ruff-format
+-   repo: local
+    hooks:
+    -   id: mypy
+        name: mypy
+        # Runs from the local dev venv (not an isolated pre-commit env) so it sees
+        # shapash's actual dependencies (dash, pandas, sklearn, ...); pyproject.toml
+        # sets ignore_missing_imports=true, which would silently mask them as Any
+        # otherwise. Requires `.venv` to be set up.
+        entry: mypy shapash
+        language: system
+        pass_filenames: false
+        files: ^shapash/.*\.py$
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.20.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,11 @@ ruff check
 ruff format
 ```
 
+Check your type annotations with mypy:
+```
+mypy shapash
+```
+
 ## Commit your changes
 
 We recommend committing with clear messages and grouping your commits by modifications dependencies.

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ lint: ## check style with ruff
 format: ## check formatting with ruff
 	ruff format --check
 
+typecheck: ## check type annotations with mypy
+	mypy shapash
+
 test: ## run tests quickly with the default Python
 	pytest
 

--- a/shapash/backend/base_backend.py
+++ b/shapash/backend/base_backend.py
@@ -41,7 +41,7 @@ class BaseBackend(ABC):
         self.model = model
         self.preprocessing = preprocessing
         self.explain_data: Any = None
-        self.state = None
+        self.state: Any = None
         self._case, self._classes = check_model(model)
         if self._case not in self.supported_cases:
             raise ValueError(f"Model not supported by the backend as it does not cover {self._case} case")

--- a/shapash/backend/lime_backend.py
+++ b/shapash/backend/lime_backend.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 try:
     from lime import lime_tabular
 
@@ -115,7 +117,7 @@ class LimeBackend(BaseBackend):
         self,
         x: pd.DataFrame,
         feature_names: list,
-        predict_fn: callable,
+        predict_fn: Callable,
         num_classes: int,
     ) -> list[pd.DataFrame]:
         """
@@ -152,7 +154,7 @@ class LimeBackend(BaseBackend):
         self,
         x: pd.DataFrame,
         feature_names: list,
-        predict_fn: callable,
+        predict_fn: Callable,
     ) -> pd.DataFrame:
         """
         Compute LIME contributions for binary classification or regression.

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -6,6 +6,7 @@ import copy
 import logging
 import shutil
 import tempfile
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -195,7 +196,7 @@ class SmartExplainer:
         features_groups=None,
         features_dict=None,
         label_dict=None,
-        title_story: str = None,
+        title_story: str | None = None,
         palette_name=None,
         colors_dict=None,
         **backend_kwargs,
@@ -246,7 +247,7 @@ class SmartExplainer:
         self.features_compacity = None
         self.contributions = None
         self.explain_data = None
-        self.features_imp = None
+        self.features_imp: Any = None
 
     def compile(
         self,
@@ -386,7 +387,7 @@ class SmartExplainer:
             raise AssertionError(f"Selected backend ({self.backend.name}) does not support groups of features.")
         # Compute contributions for groups of features
         self.contributions_groups = self.state.compute_grouped_contributions(self.contributions, features_groups)
-        self.features_imp_groups = None
+        self.features_imp_groups: Any = None
         # Update features dict with groups names
         self._update_features_dict_with_groups(features_groups=features_groups)
         # Compute t-sne projections for groups of features
@@ -478,7 +479,7 @@ class SmartExplainer:
         y_target=None,
         label_dict=None,
         features_dict=None,
-        title_story: str = None,
+        title_story: str | None = None,
         columns_order=None,
         additional_data=None,
         additional_features_dict=None,
@@ -1400,7 +1401,7 @@ class SmartExplainer:
 
         self.features_compacity = {"features_needed": features_needed, "distance_reached": distance_reached}
 
-    def init_app(self, settings: dict = None):
+    def init_app(self, settings: dict | None = None):
         """
         Initialize a SmartApp instance for the current SmartExplainer object.
 
@@ -1436,10 +1437,10 @@ class SmartExplainer:
 
     def run_app(
         self,
-        port: int = None,
-        host: str = None,
-        title_story: str = None,
-        settings: dict = None,
+        port: int | None = None,
+        host: str | None = None,
+        title_story: str | None = None,
+        settings: dict | None = None,
     ) -> CustomThread:
         """
         Launch the Shapash interpretability WebApp associated with this SmartExplainer.

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1502,13 +1502,7 @@ class SmartExplainer:
                 port = 8050
             host_name = get_host_name()
             wsgi_server = make_server(host, port, self.smartapp.server)
-            server_instance = CustomThread(target=wsgi_server.serve_forever)
-
-            def _kill():
-                wsgi_server.shutdown()
-                server_instance.killed = True
-
-            server_instance.kill = _kill
+            server_instance = CustomThread(target=wsgi_server.serve_forever, on_kill=wsgi_server.shutdown)
             if host_name is None:
                 host_name = host
             elif host != DEFAULT_HOST:

--- a/shapash/plots/plot_univariate.py
+++ b/shapash/plots/plot_univariate.py
@@ -411,7 +411,7 @@ def plot_categorical_distribution(
     else:
         color = style_dict.get(col, random_color())
 
-        customdata = subset.apply(
+        customdata = df_cat.apply(
             lambda row: (
                 f"{col}: {row[col]}<br>"
                 f"Percentage: {format(row.Percent, f'.{max(0, compute_digit_number(row.Percent, 3))}f')}%"

--- a/shapash/report/common.py
+++ b/shapash/report/common.py
@@ -1,5 +1,6 @@
 import builtins
 import os
+from collections.abc import Callable
 from enum import Enum
 from importlib import import_module
 from numbers import Number
@@ -73,7 +74,7 @@ def numeric_is_continuous(s: pd.Series, threshold: int = 15) -> bool:
     return n_unique > threshold
 
 
-def compute_col_types(df_all: pd.DataFrame | None) -> dict | None:
+def compute_col_types(df_all: pd.DataFrame | None) -> dict:
     """
     Computes the type of each column and stores the result in a dict.
 
@@ -181,7 +182,7 @@ def display_value(value: float, thousands_separator: str = ",", decimal_separato
     return value_str.replace("/thousands/", thousands_separator).replace("/decimal/", decimal_separator)
 
 
-def replace_dict_values(obj: dict, replace_fn: callable, *args) -> dict:
+def replace_dict_values(obj: dict, replace_fn: Callable, *args) -> dict:
     """
     Recursively iterates over all values of obj and changes its values using the replace_fn
 

--- a/shapash/report/generation.py
+++ b/shapash/report/generation.py
@@ -3,6 +3,7 @@ Report generation helper module.
 """
 
 import os
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import papermill as pm
@@ -10,10 +11,13 @@ from nbconvert import HTMLExporter
 
 from shapash.utils.utils import get_project_root
 
+if TYPE_CHECKING:
+    from shapash.explainer.smart_explainer import SmartExplainer
+
 
 def execute_report(
     working_dir: str,
-    explainer: object,
+    explainer: "SmartExplainer",
     project_info_file: str,
     x_train: pd.DataFrame | None = None,
     y_train: pd.DataFrame | None = None,

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -98,22 +98,22 @@ class ProjectReport:
         self.target_name = target_name_train or target_name_test
 
         if "max_points" in self.config.keys():
-            self.max_points = config["max_points"]
+            self.max_points = self.config["max_points"]
         else:
             self.max_points = 200
 
         if "display_interaction_plot" in self.config.keys():
-            self.display_interaction_plot = config["display_interaction_plot"]
+            self.display_interaction_plot = self.config["display_interaction_plot"]
         else:
             self.display_interaction_plot = False
 
         if "nb_top_interactions" in self.config.keys():
-            self.nb_top_interactions = config["nb_top_interactions"]
+            self.nb_top_interactions = self.config["nb_top_interactions"]
         else:
             self.nb_top_interactions = 5
 
         if "title_story" in self.config.keys():
-            self.title_story = config["title_story"]
+            self.title_story = self.config["title_story"]
         elif self.explainer.title_story != "":
             self.title_story = self.explainer.title_story
         else:

--- a/shapash/report/project_report.py
+++ b/shapash/report/project_report.py
@@ -4,6 +4,7 @@ import os
 import sys
 from datetime import date
 from numbers import Number
+from typing import cast
 
 import jinja2
 import numpy as np
@@ -88,7 +89,9 @@ class ProjectReport:
         self.x_init = self.explainer.x_init
         self.config = config if config is not None else dict()
         self.col_names = list(self.explainer.columns_dict.values())
-        self.df_train_test = self._create_train_test_df(test=self.x_init, train=self.x_train_pre)
+        # x_init is always set on a compiled explainer, so `test` is never None here and
+        # `_create_train_test_df` cannot return None.
+        self.df_train_test = cast(pd.DataFrame, self._create_train_test_df(test=self.x_init, train=self.x_train_pre))
         if self.explainer.y_pred is not None:
             self.y_pred = np.array(self.explainer.y_pred.T)[0]
         else:
@@ -136,7 +139,7 @@ class ProjectReport:
     @staticmethod
     def _get_values_and_name(
         y: pd.DataFrame | pd.Series | list | None, default_name: str
-    ) -> tuple[list, str] | tuple[None, None]:
+    ) -> tuple[list | None, str | None]:
         """
         Extracts vales and column name from a Pandas Series, DataFrame, or assign a default
         name if y is a list of values.

--- a/shapash/utils/custom_thread.py
+++ b/shapash/utils/custom_thread.py
@@ -4,6 +4,7 @@ Override threading custom module
 
 import sys
 import threading
+from collections.abc import Callable
 
 
 class CustomThread(threading.Thread):
@@ -14,12 +15,17 @@ class CustomThread(threading.Thread):
     ----------
     threading : threading.Thread
         Thread which you want to instanciate
+    on_kill : Callable, optional
+        Extra callback invoked when the thread is killed, in addition to
+        stopping the traced run loop (e.g. to shut down a server bound to
+        this thread).
     """
 
-    def __init__(self, *args, **keywords):
+    def __init__(self, *args, on_kill: Callable[[], None] | None = None, **keywords):
         threading.Thread.__init__(self, *args, **keywords)
         self.killed = False
         self.__run_backup = None
+        self.on_kill = on_kill
 
     def start(self):
         """Starts the thread"""
@@ -54,4 +60,6 @@ class CustomThread(threading.Thread):
         """
         Kill the current Thread
         """
+        if self.on_kill is not None:
+            self.on_kill()
         self.killed = True

--- a/shapash/utils/utils.py
+++ b/shapash/utils/utils.py
@@ -352,7 +352,7 @@ def compute_top_correlations_features(corr: pd.DataFrame, max_features: int) -> 
     list
     """
     sorted_corr = corr.abs().unstack().sort_values(kind="quicksort")[::-1]
-    set_features = set()
+    set_features: set = set()
     i = 0
     while len(set_features) < max_features and i < len(sorted_corr):
         if sorted_corr.index[i][0] != sorted_corr.index[i][1]:

--- a/shapash/webapp/smart_app.py
+++ b/shapash/webapp/smart_app.py
@@ -7,6 +7,7 @@ import copy
 import random
 import re
 from math import isfinite, log10
+from typing import Any
 
 import dash
 import dash_bootstrap_components as dbc
@@ -69,7 +70,7 @@ class SmartApp:
         SmartExplainer instance to point to.
     """
 
-    def __init__(self, explainer, settings: dict = None):
+    def __init__(self, explainer, settings: dict | None = None):
         """
         Init on class instantiation, everything to be able to run the app on server.
         Parameters
@@ -129,7 +130,7 @@ class SmartApp:
             self.label = None
             self.selected_feature = self.explainer.features_imp.idxmax()
             self.max_threshold = self.explainer.contributions.map(lambda x: round_to_k(x, k=1)).max().max()
-        self.list_index = []
+        self.list_index: list = []
         self.subset = None
         self.last_click_data = None
 
@@ -141,11 +142,17 @@ class SmartApp:
         self.init_data()
 
         # COMPONENTS
-        self.components = {"menu": {}, "table": {}, "graph": {}, "filter": {}, "settings": {}}
+        self.components: dict[str, dict[str, Any]] = {
+            "menu": {},
+            "table": {},
+            "graph": {},
+            "filter": {},
+            "settings": {},
+        }
         self.init_components()
 
         # LAYOUT
-        self.skeleton = {"navbar": {}, "body": {}}
+        self.skeleton: dict[str, Any] = {"navbar": {}, "body": {}}
         self.make_skeleton()
         self.app.layout = html.Div([self.skeleton["navbar"], self.skeleton["body"]])
 

--- a/shapash/webapp/utils/callbacks.py
+++ b/shapash/webapp/utils/callbacks.py
@@ -269,7 +269,7 @@ def get_indexes_from_datatable(data: list, list_index: list | None = None) -> li
     """
     indexes = [d["_index_"] for d in data]
     if list_index is not None and (len(indexes) == len(list_index) or len(indexes) == 0):
-        indexes = None
+        return None
     return indexes
 
 
@@ -399,7 +399,7 @@ def get_id_card_features(data: list, selected: int, special_cols: list, features
 
 
 def get_id_card_contrib(
-    data: dict, index: int, features_dict: dict, columns_dict: dict, label_num: int = None
+    data: dict, index: int, features_dict: dict, columns_dict: dict, label_num: int | None = None
 ) -> pd.DataFrame:
     """Get the contributions of the selected index for the identity card.
 
@@ -642,9 +642,10 @@ def create_filter_modalities_selection(value: str, filter_id: dict, round_datafr
     _first = _non_null.iloc[0] if len(_non_null) > 0 else None
 
     if type(_first) is np.bool_ or type(_first) is bool:
+        radio_options: list[dcc.RadioItems.Options] = [{"label": str(val), "value": val} for val in _non_null.unique()]
         new_element = html.Div(
             dcc.RadioItems(
-                [{"label": str(val), "value": val} for val in _non_null.unique()],
+                radio_options,
                 id={"type": "dynamic-bool", "index": filter_id["index"]},
                 value=_first,
                 inline=False,
@@ -655,10 +656,11 @@ def create_filter_modalities_selection(value: str, filter_id: dict, round_datafr
         # If feature has integer type with at most 20 values or string type (no limits on number of values),
         # then display Dropdown component
         # Notice that integer column with NaN values is considered as float, so it will not be displayed as Dropdown.
+        dropdown_options: list[dcc.Dropdown.Options] = [{"label": i, "value": i} for i in np.sort(_non_null.unique())]
         new_element = html.Div(
             dcc.Dropdown(
                 id={"type": "dynamic-str", "index": filter_id["index"]},
-                options=[{"label": i, "value": i} for i in np.sort(_non_null.unique())],
+                options=dropdown_options,
                 multi=True,
             ),
             style={"width": "65%", "margin-left": "20px"},
@@ -701,17 +703,19 @@ def create_filter_modalities_selection(value: str, filter_id: dict, round_datafr
     return new_element
 
 
-def handle_page_navigation(triggered_input: str, page: int | str, selected_feature: str) -> tuple[int, str]:
+def handle_page_navigation(
+    triggered_input: str, page: int | str, selected_feature: str | None
+) -> tuple[int, str | None]:
     """
     Handle the navigation between different pages based on user input.
 
     Args:
         triggered_input (str): The input that triggered the navigation.
         page (Union[int, str]): The current page number.
-        selected_feature (str): The currently selected feature.
+        selected_feature (Optional[str]): The currently selected feature.
 
     Returns:
-        tuple[int, str]: Updated page number and selected feature.
+        tuple[int, Optional[str]]: Updated page number and selected feature.
     """
     page = int(page)
     if triggered_input == "page_left.n_clicks":
@@ -746,7 +750,7 @@ def update_click_data_on_subset_changes_if_needed(click_data: dict, triggered_in
     return click_data
 
 
-def get_selected_feature(click_data: dict, inv_features_dict: dict) -> str:
+def get_selected_feature(click_data: dict, inv_features_dict: dict) -> str | None:
     """
     Retrieve the selected feature from the click data.
 
@@ -755,7 +759,7 @@ def get_selected_feature(click_data: dict, inv_features_dict: dict) -> str:
         inv_features_dict (dict): Dictionary mapping feature IDs to feature names.
 
     Returns:
-        str: The selected feature, if any.
+        Optional[str]: The selected feature, if any.
     """
     return inv_features_dict.get(get_feature_from_clicked_data(click_data)) if click_data else None
 
@@ -763,28 +767,29 @@ def get_selected_feature(click_data: dict, inv_features_dict: dict) -> str:
 def handle_group_display_logic(
     bool_group: bool,
     triggered_input: str,
-    selected_feature: str,
+    selected_feature: str | None,
     selected_click_data,
-    click_data: dict,
+    click_data: dict | None,
     click_data_store: dict,
     selected_click_data_store,
     features_groups: dict,
     features_dict: dict,
-) -> tuple[str, str, dict]:
+) -> tuple[str | None, str | None, dict | None, object]:
     """
     Handle the display logic for feature groups.
 
     Args:
         bool_group (bool): Whether to display feature groups.
         triggered_input (str): The input that triggered the update.
-        selected_feature (str): The currently selected feature.
-        click_data (dict): The current click data.
+        selected_feature (Optional[str]): The currently selected feature.
+        click_data (Optional[dict]): The current click data.
         click_data_store (dict): Stored click data.
         features_groups (dict): Dictionary of feature groups.
         features_dict (dict): Dictionary of features.
 
     Returns:
-        tuple[str, str, dict]: Updated selected feature, group name, and click data.
+        tuple[Optional[str], Optional[str], Optional[dict], object]: Updated selected feature,
+        group name, click data, and selected click data.
     """
     group_name = None
     selected_feature_group = None
@@ -823,7 +828,7 @@ def handle_group_display_logic(
 
 def determine_total_pages_and_display(
     explainer: "SmartExplainer", features: int, bool_group: bool, group_name: str, page: int
-) -> tuple[int, str, int]:
+) -> tuple[int, dict[str, str], int]:
     """
     Determine the total number of pages and the display properties.
 
@@ -835,7 +840,7 @@ def determine_total_pages_and_display(
         page (int): Current page number.
 
     Returns:
-        tuple[int, str, int]: Total pages, display properties, and updated page number.
+        tuple[int, dict[str, str], int]: Total pages, display properties, and updated page number.
     """
     display_groups = explainer.features_groups is not None and bool_group
     if explainer._case == "classification":

--- a/shapash/webapp/webapp_launch.py
+++ b/shapash/webapp/webapp_launch.py
@@ -93,6 +93,8 @@ else:
         },
     }
 
+additional_features_dict: dict | None = None
+
 if CASE == 1:
     features = ["Pclass", "Survived", "Embarked", "Sex", "Age", "SibSp", "Parch"]
     for col in list(feature_dict.keys()):

--- a/tests/unit_tests/report/test_plots.py
+++ b/tests/unit_tests/report/test_plots.py
@@ -88,6 +88,19 @@ class TestPlots(unittest.TestCase):
         assert fig.data[1].type == "bar"
         assert len(fig.data[0]['x']) == 2
 
+    def test_plot_categorical_distribution_no_hue(self):
+        """
+        Test that the plot can be generated without a hue/col_splitter column.
+        """
+        df = pd.DataFrame({"int_data": [0, 0, 0, 1, 1, 0]})
+
+        fig = plot_categorical_distribution(df, "int_data")
+
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) == 1
+        assert fig.data[0].type == "bar"
+        assert len(fig.data[0]["x"]) == 2
+
     def test_plot_categorical_distribution_2(self):
         df = pd.DataFrame(
             {"int_data": [0, 0, 0, 1, 1, 0], "data_train_test": ["train", "train", "train", "train", "train", "train"]}


### PR DESCRIPTION
# Summary

Fixes all 52 mypy shapash errors (previously unenforced). Along the way, this surfaced two real bugs and one unsound runtime pattern, which are fixed separately from the pure type-annotation work.
Adds `mypy` checks in CI, pre-commit and Makefile for dev adoption.

Fixes #743 

## Bug fixes
- `shapash/plots/plot_univariate.py`: `plot_categorical_distribution`'s no-hue branch referenced an undefined subset variable (a copy-paste leftover from the hue branch a few lines above), raising a `NameError` on every call made without `hue`. Fixed to use `df_cat`, the dataframe already used correctly two lines later. No existing test exercised this path, added `test_plot_categorical_distribution_no_hue` in `tests/unit_tests/report/test_plots.py`.
- `shapash/report/project_report.py`: `ProjectReport.__init__` read four config values (`max_points`, `display_interaction_plot`, `nb_top_interactions`, `title_story`) from the raw config constructor argument (typed `dict | None`) instead of `self.config` (the version already coerced to `{}` when `None`). Not reachable as a crash today, but incorrect and exactly what led mypy to flag it.

## Design fix
- `shapash/utils/custom_thread.py` / `shapash/explainer/smart_explainer.py`: `run_app()` used to overwrite `CustomThread`'s real `kill()` method at runtime (`server_instance.kill = _kill`) with an incompatible closure, which mypy correctly flagged as unsound. Replaced with a proper `on_kill: Callable[[], None] | None` constructor parameter on `CustomThread`; `kill()` now invokes it before setting `killed = True`, and `run_app` passes `on_kill=wsgi_server.shutdown` instead of monkey-patching. Behaviour is unchanged (verified manually with a live, non-mocked thread).

## Type-annotation changes (no behavior change)
- `callable` (not a valid type) → `collections.abc.Callable` in `base_backend.py`, `lime_backend.py`, `common.py`.
- Fixed several attributes/functions whose declared type didn't match reality:
  - `BaseBackend.state`, `SmartExplainer.features_imp`/`features_imp_groups` were locked to type `None` (from `self.x = None` in `__init__` with no annotation) — annotated as `Any`.
  - `compute_col_types` was typed -> `dict | None` but never returns `None` — narrowed to -> `dict`.
  - `execute_report's explainer`: object param → typed as `"SmartExplainer"` via a `TYPE_CHECKING`-guarded import (avoids the circular import that likely motivated the original object).
  - `ProjectReport._get_values_and_name` return type widened from `tuple[list, str] | tuple[None, None]` to `tuple[list | None, str | None]` for cleaner unpacking; `df_train_test` narrowed with `typing.cast` (not `assert`, to avoid ruff S101) since `x_init` is always set on a compiled explainer.
- Widened implicit-`Optional` defaults (`x: int = None` → `x: int | None = None`) across `smart_explainer.py` (`title_story`, `settings`, `port`, `host` in `__init__`/`init_app`/`run_app`), `smart_app.py` (settings), `callbacks.py` (`label_num`, `selected_feature`, `click_data`), and `webapp_launch.py` (`additional_features_dict`).
- Annotated previously-untyped empty containers: `utils.py` (`set_features: set`), `smart_app.py` (`list_index`, `components`, `skeleton`).
- Corrected `callbacks.py` return-type signatures that didn't match actual behavior (`handle_page_navigation`, `get_selected_feature`, `handle_group_display_logic`, `determine_total_pages_and_display` — the latter's `display_page` is a `dict[str, str]`, not `str`).
- Typed Dash `RadioItems`/`Dropdown` options lists against the components' own `Options` TypedDicts instead of a plain `list[dict]`.
- Restructured `get_indexes_from_datatable` to return early rather than reassigning a differently-typed value into the same variable.

# How Has This Been Tested?

- `mypy shapash` → clean (was 52 errors across 11 files)
- `ruff check shapash` / `ruff format --check shapash` → clean
- `pytest tests/unit_tests` → 543 passed, including the new regression test

**Test Configuration**:
* OS: Linux
* Python version: 3.13.13
* Shapash version: 2.9.0
