### PR TITLE
fix(pre-commit): use venv mypy path directly so hook works in VSCode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,9 @@ repos:
     -   id: mypy
         name: mypy
         # Runs from the local dev venv (not an isolated pre-commit env) so it sees
-        # shapash's actual dependencies (dash, pandas, sklearn, ...); pyproject.toml
-        # sets ignore_missing_imports=true, which would silently mask them as Any
-        # otherwise. Requires `.venv` to be set up.
-        entry: mypy shapash
+        # shapash's actual dependencies. Path is explicit (not just `mypy`) so it
+        # also works from GUI clients like VSCode, whose PATH isn't venv-activated.
+        entry: .venv/bin/mypy shapash
         language: system
         pass_filenames: false
         files: ^shapash/.*\.py$


### PR DESCRIPTION
Points the mypy pre-commit hook at `.venv/bin/mypy` directly instead of a bare mypy lookup on `PATH`, so it works from VSCode's Source Control (whose process env doesn't have the venv activated) as well as the command line.

Tested with adding in `shapash`
```
def test_func(a: str) -> int:
    """Test function to check pre-commit hooks."""
    return a
```
and trying to commit via VSCode Source Control. It returns a mypy failure as expected.