### PR TITLE
feat(smartpredictor): add lightweight schema-drift detection

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -29,6 +29,7 @@ from shapash.utils.check import (
     check_y,
 )
 from shapash.utils.custom_thread import CustomThread
+from shapash.utils.drift import compute_schema_distribution
 from shapash.utils.explanation_metrics import find_neighbors, get_distance, get_min_nb_features, shap_neighbors
 from shapash.utils.io import load_pickle, save_pickle
 from shapash.utils.model import predict, predict_error, predict_proba
@@ -1565,6 +1566,9 @@ class SmartExplainer:
           List of class labels for classification models, `None` for regression.
         - **mask_params** : dict, optional
           Parameters defining contribution filters used to summarize local explainability.
+        - **schema_distribution** : dict
+          Compact numeric and categorical summaries computed from the reference dataset
+          and used to warn about drift in new SmartPredictor input batches.
 
         Example
         -------
@@ -1601,6 +1605,8 @@ class SmartExplainer:
         if not hasattr(self, "mask_params"):
             self.mask_params = {"features_to_hide": None, "threshold": None, "positive": None, "max_contrib": None}
         params_smartpredictor.append(self.mask_params)
+
+        params_smartpredictor.append(compute_schema_distribution(self.x_init))
 
         return shapash.explainer.smart_predictor.SmartPredictor(*params_smartpredictor)
 

--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -29,7 +29,7 @@ from shapash.utils.check import (
     check_y,
 )
 from shapash.utils.custom_thread import CustomThread
-from shapash.utils.drift import compute_schema_distribution
+from shapash.utils.drift import compute_schema_distribution, resolve_schema_drift_config
 from shapash.utils.explanation_metrics import find_neighbors, get_distance, get_min_nb_features, shap_neighbors
 from shapash.utils.io import load_pickle, save_pickle
 from shapash.utils.model import predict, predict_error, predict_proba
@@ -1517,7 +1517,7 @@ class SmartExplainer:
         else:
             raise ValueError("Explainer must be compiled before running app.")
 
-    def to_smartpredictor(self):
+    def to_smartpredictor(self, schema_drift_config: dict[str, float | int] | None = None):
         """
         Create and return a SmartPredictor object derived from the current SmartExplainer instance.
 
@@ -1528,6 +1528,16 @@ class SmartExplainer:
         The generated `SmartPredictor` includes the model, preprocessing and postprocessing
         steps, feature and label mappings, and backend configuration used to compute
         contributions.
+
+        Parameters
+        ----------
+        schema_drift_config : dict, optional
+            Override schema-drift thresholds and sampling settings. Unspecified settings
+            retain their defaults. Supported keys are ``missing_rate_delta_threshold``
+            (0.10), ``numeric_median_iqr_threshold`` (1.5),
+            ``categorical_tvd_threshold`` (0.20),
+            ``categorical_cardinality_ratio_threshold`` (1.5), ``top_k`` (10),
+            and ``min_sample_size`` (30).
 
         Returns
         -------
@@ -1569,6 +1579,8 @@ class SmartExplainer:
         - **schema_distribution** : dict
           Compact numeric and categorical summaries computed from the reference dataset
           and used to warn about drift in new SmartPredictor input batches.
+        - **schema_drift_config** : dict
+          Resolved thresholds and sampling settings used for drift detection.
 
         Example
         -------
@@ -1606,7 +1618,11 @@ class SmartExplainer:
             self.mask_params = {"features_to_hide": None, "threshold": None, "positive": None, "max_contrib": None}
         params_smartpredictor.append(self.mask_params)
 
-        params_smartpredictor.append(compute_schema_distribution(self.x_init))
+        resolved_drift_config = resolve_schema_drift_config(schema_drift_config)
+        params_smartpredictor.append(
+            compute_schema_distribution(self.x_init, top_k=int(resolved_drift_config["top_k"]))
+        )
+        params_smartpredictor.append(resolved_drift_config)
 
         return shapash.explainer.smart_predictor.SmartPredictor(*params_smartpredictor)
 

--- a/shapash/explainer/smart_predictor.py
+++ b/shapash/explainer/smart_predictor.py
@@ -6,6 +6,7 @@ import copy
 import functools
 import logging
 import time
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -35,6 +36,7 @@ from shapash.utils.check import (
     check_y,
 )
 from shapash.utils.columntransformer_backend import columntransformer
+from shapash.utils.drift import compute_schema_distribution, detect_schema_drift
 from shapash.utils.io import _build_predictor_manifest, _compute_schema_fingerprint, _save_manifest, save_pickle
 from shapash.utils.model import predict_proba
 from shapash.utils.transform import adapt_contributions, apply_postprocessing, apply_preprocessing, preprocessing_tolist
@@ -165,6 +167,8 @@ class SmartPredictor:
         List of labels if the model used is for classification problem, None otherwise.
     mask_params: dict (optional)
         Dictionary that specify how to summarize the explainability.
+    schema_distribution: dict (optional)
+        Compact reference summaries used to detect drift in new input batches.
 
     How to declare a new SmartPredictor object?
 
@@ -199,6 +203,7 @@ class SmartPredictor:
         postprocessing=None,
         features_groups=None,
         mask_params=None,
+        schema_distribution: dict[Any, dict[str, Any]] | None = None,
     ):
         params_dict = [features_dict, features_types, label_dict, columns_dict, postprocessing]
 
@@ -228,6 +233,7 @@ class SmartPredictor:
         self.check_mask_params()
         self.postprocessing = postprocessing
         self.features_groups = features_groups
+        self.schema_distribution = schema_distribution
         list_preprocessing = preprocessing_tolist(self.preprocessing)
         check_consistency_model_features(
             self.features_dict,
@@ -312,6 +318,7 @@ class SmartPredictor:
             )
         if x is not None:
             x = self.check_dataset_features(self.check_dataset_type(x))
+            self._check_schema_drift(x)
             self.data = self.clean_data(x)
             self.data["x_postprocessed"] = self.apply_postprocessing()
             try:
@@ -338,6 +345,27 @@ class SmartPredictor:
 
         if self.features_groups is not None:
             self._add_groups_input()
+
+    def _check_schema_drift(self, x: pd.DataFrame) -> None:
+        """Warn and log when ``x`` materially differs from the reference distribution."""
+        reference = getattr(self, "schema_distribution", None)
+        if not reference:
+            return
+
+        drift = detect_schema_drift(reference, compute_schema_distribution(x))
+        fingerprint = self._get_schema_fingerprint()
+        for column, reasons in drift.items():
+            details = "; ".join(reasons)
+            message = f"Potential schema drift detected for '{column}': {details}"
+            warnings.warn(message, UserWarning, stacklevel=3)
+            _logger.warning(
+                message,
+                extra={
+                    "schema_fingerprint": fingerprint,
+                    "drift_column": column,
+                    "drift_reasons": tuple(reasons),
+                },
+            )
 
     def _add_groups_input(self):
         """

--- a/shapash/explainer/smart_predictor.py
+++ b/shapash/explainer/smart_predictor.py
@@ -36,7 +36,7 @@ from shapash.utils.check import (
     check_y,
 )
 from shapash.utils.columntransformer_backend import columntransformer
-from shapash.utils.drift import compute_schema_distribution, detect_schema_drift
+from shapash.utils.drift import compute_schema_distribution, detect_schema_drift, resolve_schema_drift_config
 from shapash.utils.io import _build_predictor_manifest, _compute_schema_fingerprint, _save_manifest, save_pickle
 from shapash.utils.model import predict_proba
 from shapash.utils.transform import adapt_contributions, apply_postprocessing, apply_preprocessing, preprocessing_tolist
@@ -169,6 +169,8 @@ class SmartPredictor:
         Dictionary that specify how to summarize the explainability.
     schema_distribution: dict (optional)
         Compact reference summaries used to detect drift in new input batches.
+    schema_drift_config: dict (optional)
+        Thresholds and sampling settings used for schema-drift detection.
 
     How to declare a new SmartPredictor object?
 
@@ -204,6 +206,7 @@ class SmartPredictor:
         features_groups=None,
         mask_params=None,
         schema_distribution: dict[Any, dict[str, Any]] | None = None,
+        schema_drift_config: dict[str, float | int] | None = None,
     ):
         params_dict = [features_dict, features_types, label_dict, columns_dict, postprocessing]
 
@@ -234,6 +237,7 @@ class SmartPredictor:
         self.postprocessing = postprocessing
         self.features_groups = features_groups
         self.schema_distribution = schema_distribution
+        self.schema_drift_config = resolve_schema_drift_config(schema_drift_config)
         list_preprocessing = preprocessing_tolist(self.preprocessing)
         check_consistency_model_features(
             self.features_dict,
@@ -352,7 +356,9 @@ class SmartPredictor:
         if not reference:
             return
 
-        drift = detect_schema_drift(reference, compute_schema_distribution(x))
+        config = resolve_schema_drift_config(getattr(self, "schema_drift_config", None))
+        current = compute_schema_distribution(x, top_k=int(config["top_k"]))
+        drift = detect_schema_drift(reference, current, config)
         fingerprint = self._get_schema_fingerprint()
         for column, reasons in drift.items():
             details = "; ".join(reasons)

--- a/shapash/utils/drift.py
+++ b/shapash/utils/drift.py
@@ -86,7 +86,7 @@ def _numeric_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list
     current_median = current.get("median")
     reference_q25 = reference.get("q25")
     reference_q75 = reference.get("q75")
-    if None in (reference_median, current_median, reference_q25, reference_q75):
+    if reference_median is None or current_median is None or reference_q25 is None or reference_q75 is None:
         return []
 
     iqr = float(reference_q75) - float(reference_q25)

--- a/shapash/utils/drift.py
+++ b/shapash/utils/drift.py
@@ -11,6 +11,42 @@ CATEGORICAL_CARDINALITY_RATIO_THRESHOLD = 1.5
 DEFAULT_TOP_K = 10
 MIN_DRIFT_SAMPLE_SIZE = 30
 
+DEFAULT_SCHEMA_DRIFT_CONFIG: dict[str, float | int] = {
+    "missing_rate_delta_threshold": MISSING_RATE_DELTA_THRESHOLD,
+    "numeric_median_iqr_threshold": NUMERIC_MEDIAN_IQR_THRESHOLD,
+    "categorical_tvd_threshold": CATEGORICAL_TVD_THRESHOLD,
+    "categorical_cardinality_ratio_threshold": CATEGORICAL_CARDINALITY_RATIO_THRESHOLD,
+    "top_k": DEFAULT_TOP_K,
+    "min_sample_size": MIN_DRIFT_SAMPLE_SIZE,
+}
+
+
+def resolve_schema_drift_config(config: dict[str, float | int] | None = None) -> dict[str, float | int]:
+    """Merge user-provided schema-drift settings with validated defaults."""
+    resolved = DEFAULT_SCHEMA_DRIFT_CONFIG.copy()
+    if config is None:
+        return resolved
+    if not isinstance(config, dict):
+        raise ValueError("schema_drift_config must be a dict.")
+
+    unknown = set(config) - set(resolved)
+    if unknown:
+        raise ValueError(f"Unknown schema drift configuration keys: {sorted(unknown)}")
+    resolved.update(config)
+
+    for key in (
+        "missing_rate_delta_threshold",
+        "numeric_median_iqr_threshold",
+        "categorical_tvd_threshold",
+        "categorical_cardinality_ratio_threshold",
+    ):
+        if not isinstance(resolved[key], (int, float)) or isinstance(resolved[key], bool) or resolved[key] < 0:
+            raise ValueError(f"schema_drift_config['{key}'] must be a non-negative number.")
+    for key in ("top_k", "min_sample_size"):
+        if not isinstance(resolved[key], int) or isinstance(resolved[key], bool) or resolved[key] < 1:
+            raise ValueError(f"schema_drift_config['{key}'] must be a positive integer.")
+    return resolved
+
 
 def compute_schema_distribution(x: pd.DataFrame, top_k: int = DEFAULT_TOP_K) -> dict[Any, dict[str, Any]]:
     """Return compact per-column distribution summaries for ``x``."""
@@ -50,8 +86,10 @@ def compute_schema_distribution(x: pd.DataFrame, top_k: int = DEFAULT_TOP_K) -> 
 def detect_schema_drift(
     reference: dict[Any, dict[str, Any]],
     current: dict[Any, dict[str, Any]],
+    config: dict[str, float | int] | None = None,
 ) -> dict[Any, list[str]]:
     """Return actionable drift reasons keyed by column name."""
+    resolved_config = resolve_schema_drift_config(config)
     drift: dict[Any, list[str]] = {}
     for column, reference_summary in reference.items():
         current_summary = current.get(column)
@@ -59,29 +97,42 @@ def detect_schema_drift(
             continue
         if (
             min(int(reference_summary.get("sample_size", 0)), int(current_summary.get("sample_size", 0)))
-            < MIN_DRIFT_SAMPLE_SIZE
+            < resolved_config["min_sample_size"]
         ):
             continue
 
-        reasons = _missing_rate_reasons(reference_summary, current_summary)
+        reasons = _missing_rate_reasons(
+            reference_summary, current_summary, float(resolved_config["missing_rate_delta_threshold"])
+        )
         if reference_summary["kind"] == "numeric":
-            reasons.extend(_numeric_reasons(reference_summary, current_summary))
+            reasons.extend(
+                _numeric_reasons(
+                    reference_summary, current_summary, float(resolved_config["numeric_median_iqr_threshold"])
+                )
+            )
         else:
-            reasons.extend(_categorical_reasons(reference_summary, current_summary))
+            reasons.extend(
+                _categorical_reasons(
+                    reference_summary,
+                    current_summary,
+                    float(resolved_config["categorical_tvd_threshold"]),
+                    float(resolved_config["categorical_cardinality_ratio_threshold"]),
+                )
+            )
         if reasons:
             drift[column] = reasons
     return drift
 
 
-def _missing_rate_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list[str]:
+def _missing_rate_reasons(reference: dict[str, Any], current: dict[str, Any], threshold: float) -> list[str]:
     reference_rate = float(reference["missing_rate"])
     current_rate = float(current["missing_rate"])
-    if abs(current_rate - reference_rate) < MISSING_RATE_DELTA_THRESHOLD:
+    if abs(current_rate - reference_rate) < threshold:
         return []
     return [f"missing rate changed from {reference_rate:.3f} to {current_rate:.3f}"]
 
 
-def _numeric_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list[str]:
+def _numeric_reasons(reference: dict[str, Any], current: dict[str, Any], threshold: float) -> list[str]:
     reference_median = reference.get("median")
     current_median = current.get("median")
     reference_q25 = reference.get("q25")
@@ -92,12 +143,14 @@ def _numeric_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list
     iqr = float(reference_q75) - float(reference_q25)
     scale = max(abs(iqr), 1e-12)
     normalized_shift = abs(float(current_median) - float(reference_median)) / scale
-    if normalized_shift < NUMERIC_MEDIAN_IQR_THRESHOLD:
+    if normalized_shift < threshold:
         return []
     return [f"median shifted by {normalized_shift:.2f} reference IQRs"]
 
 
-def _categorical_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list[str]:
+def _categorical_reasons(
+    reference: dict[str, Any], current: dict[str, Any], tvd_threshold: float, cardinality_ratio_threshold: float
+) -> list[str]:
     reference_top = reference.get("top_frequencies", {})
     current_top = current.get("top_frequencies", {})
     categories = set(reference_top)
@@ -108,15 +161,12 @@ def _categorical_reasons(reference: dict[str, Any], current: dict[str, Any]) -> 
     )
 
     reasons: list[str] = []
-    if total_variation >= CATEGORICAL_TVD_THRESHOLD:
+    if total_variation >= tvd_threshold:
         reasons.append(f"category-frequency total variation is {total_variation:.3f}")
 
     reference_cardinality = int(reference.get("cardinality", 0))
     current_cardinality = int(current.get("cardinality", 0))
-    if (
-        reference_cardinality > 0
-        and current_cardinality / reference_cardinality >= CATEGORICAL_CARDINALITY_RATIO_THRESHOLD
-    ):
+    if reference_cardinality > 0 and current_cardinality / reference_cardinality >= cardinality_ratio_threshold:
         reasons.append(f"cardinality changed from {reference_cardinality} to {current_cardinality}")
     return reasons
 

--- a/shapash/utils/drift.py
+++ b/shapash/utils/drift.py
@@ -1,0 +1,126 @@
+"""Lightweight schema-distribution summaries and drift detection."""
+
+from typing import Any
+
+import pandas as pd
+
+MISSING_RATE_DELTA_THRESHOLD = 0.10
+NUMERIC_MEDIAN_IQR_THRESHOLD = 1.5
+CATEGORICAL_TVD_THRESHOLD = 0.20
+CATEGORICAL_CARDINALITY_RATIO_THRESHOLD = 1.5
+DEFAULT_TOP_K = 10
+MIN_DRIFT_SAMPLE_SIZE = 30
+
+
+def compute_schema_distribution(x: pd.DataFrame, top_k: int = DEFAULT_TOP_K) -> dict[Any, dict[str, Any]]:
+    """Return compact per-column distribution summaries for ``x``."""
+    summaries: dict[Any, dict[str, Any]] = {}
+    for column in x.columns:
+        series = x[column]
+        non_missing = series.dropna()
+        missing_rate = float(series.isna().mean())
+
+        if pd.api.types.is_numeric_dtype(series.dtype):
+            quantiles = non_missing.quantile([0.25, 0.5, 0.75]) if not non_missing.empty else pd.Series(dtype=float)
+            summaries[column] = {
+                "kind": "numeric",
+                "sample_size": int(len(series)),
+                "missing_rate": missing_rate,
+                "min": _to_float(non_missing.min()) if not non_missing.empty else None,
+                "q25": _to_float(quantiles.loc[0.25]) if not quantiles.empty else None,
+                "median": _to_float(quantiles.loc[0.5]) if not quantiles.empty else None,
+                "q75": _to_float(quantiles.loc[0.75]) if not quantiles.empty else None,
+                "max": _to_float(non_missing.max()) if not non_missing.empty else None,
+            }
+            continue
+
+        frequencies = non_missing.map(repr).value_counts(normalize=True)
+        top_frequencies = frequencies.head(top_k)
+        summaries[column] = {
+            "kind": "categorical",
+            "sample_size": int(len(series)),
+            "missing_rate": missing_rate,
+            "cardinality": int(non_missing.nunique()),
+            "top_frequencies": {str(key): float(value) for key, value in top_frequencies.items()},
+            "other_frequency": float(max(0.0, 1.0 - top_frequencies.sum())),
+        }
+    return summaries
+
+
+def detect_schema_drift(
+    reference: dict[Any, dict[str, Any]],
+    current: dict[Any, dict[str, Any]],
+) -> dict[Any, list[str]]:
+    """Return actionable drift reasons keyed by column name."""
+    drift: dict[Any, list[str]] = {}
+    for column, reference_summary in reference.items():
+        current_summary = current.get(column)
+        if current_summary is None or current_summary.get("kind") != reference_summary.get("kind"):
+            continue
+        if (
+            min(int(reference_summary.get("sample_size", 0)), int(current_summary.get("sample_size", 0)))
+            < MIN_DRIFT_SAMPLE_SIZE
+        ):
+            continue
+
+        reasons = _missing_rate_reasons(reference_summary, current_summary)
+        if reference_summary["kind"] == "numeric":
+            reasons.extend(_numeric_reasons(reference_summary, current_summary))
+        else:
+            reasons.extend(_categorical_reasons(reference_summary, current_summary))
+        if reasons:
+            drift[column] = reasons
+    return drift
+
+
+def _missing_rate_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    reference_rate = float(reference["missing_rate"])
+    current_rate = float(current["missing_rate"])
+    if abs(current_rate - reference_rate) < MISSING_RATE_DELTA_THRESHOLD:
+        return []
+    return [f"missing rate changed from {reference_rate:.3f} to {current_rate:.3f}"]
+
+
+def _numeric_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    reference_median = reference.get("median")
+    current_median = current.get("median")
+    reference_q25 = reference.get("q25")
+    reference_q75 = reference.get("q75")
+    if None in (reference_median, current_median, reference_q25, reference_q75):
+        return []
+
+    iqr = float(reference_q75) - float(reference_q25)
+    scale = max(abs(iqr), 1e-12)
+    normalized_shift = abs(float(current_median) - float(reference_median)) / scale
+    if normalized_shift < NUMERIC_MEDIAN_IQR_THRESHOLD:
+        return []
+    return [f"median shifted by {normalized_shift:.2f} reference IQRs"]
+
+
+def _categorical_reasons(reference: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    reference_top = reference.get("top_frequencies", {})
+    current_top = current.get("top_frequencies", {})
+    categories = set(reference_top)
+    current_other = max(0.0, 1.0 - sum(float(current_top.get(key, 0.0)) for key in categories))
+    total_variation = 0.5 * (
+        sum(abs(float(reference_top.get(key, 0.0)) - float(current_top.get(key, 0.0))) for key in categories)
+        + abs(float(reference.get("other_frequency", 0.0)) - current_other)
+    )
+
+    reasons: list[str] = []
+    if total_variation >= CATEGORICAL_TVD_THRESHOLD:
+        reasons.append(f"category-frequency total variation is {total_variation:.3f}")
+
+    reference_cardinality = int(reference.get("cardinality", 0))
+    current_cardinality = int(current.get("cardinality", 0))
+    if (
+        reference_cardinality > 0
+        and current_cardinality / reference_cardinality >= CATEGORICAL_CARDINALITY_RATIO_THRESHOLD
+    ):
+        reasons.append(f"cardinality changed from {reference_cardinality} to {current_cardinality}")
+    return reasons
+
+
+def _to_float(value: Any) -> float:
+    """Convert numpy and pandas scalar values to a builtin float."""
+    return float(value)

--- a/tests/unit_tests/explainer/test_smart_predictor.py
+++ b/tests/unit_tests/explainer/test_smart_predictor.py
@@ -6,6 +6,7 @@ import logging
 import os
 import types
 import unittest
+import warnings
 from os import path
 from pathlib import Path
 from unittest.mock import patch
@@ -1302,7 +1303,7 @@ class TestSmartPredictorLogging(unittest.TestCase):
 
     def test_add_input_emits_enter_and_completed_records(self) -> None:
         predictor = self._make_predictor()
-        x = pd.DataFrame([[1, 2, 4], [1, 2, 3]])
+        x = pd.DataFrame({0: np.arange(100), 1: np.arange(100, 200), 2: np.arange(200, 300)})
         with self.assertLogs(self.LOGGER_NAME, level=logging.DEBUG) as ctx:
             predictor.add_input(x=x)
         assert self._messages(ctx.records, "add_input", "enter"), "expected add_input enter record"
@@ -1378,3 +1379,60 @@ class TestSmartPredictorLogging(unittest.TestCase):
         finally:
             logger.setLevel(prev_level)
         assert logger.handlers == []
+
+
+class TestSmartPredictorSchemaDrift(unittest.TestCase):
+    """Integration tests for https://github.com/MAIF/shapash/issues/755."""
+
+    LOGGER_NAME = "shapash.smartpredictor"
+
+    def _make_predictor(self) -> SmartPredictor:
+        dataframe_x = pd.DataFrame(
+            {
+                0: np.arange(100),
+                1: np.arange(100, 200),
+                2: np.arange(200, 300),
+            }
+        )
+        target = np.tile([0, 1], 50)
+        clf = cb.CatBoostClassifier(n_estimators=1, verbose=False).fit(dataframe_x, target)
+        y_pred = pd.DataFrame(clf.predict(dataframe_x), columns=["pred"])
+        xpl = SmartExplainer(model=clf, features_dict={})
+        xpl.compile(x=dataframe_x, y_pred=y_pred)
+        return xpl.to_smartpredictor()
+
+    def test_to_smartpredictor_stores_reference_distribution(self) -> None:
+        predictor = self._make_predictor()
+
+        assert predictor.schema_distribution
+        assert set(predictor.schema_distribution) == {0, 1, 2}
+
+    def test_add_input_stable_data_does_not_warn(self) -> None:
+        predictor = self._make_predictor()
+        x = pd.DataFrame({0: np.arange(100), 1: np.arange(100, 200), 2: np.arange(200, 300)})
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            predictor.add_input(x=x)
+
+    def test_add_input_drift_warns_and_logs_with_fingerprint(self) -> None:
+        predictor = self._make_predictor()
+        shifted = pd.DataFrame({0: np.arange(500, 600), 1: np.arange(600, 700), 2: np.arange(700, 800)})
+
+        with self.assertLogs(self.LOGGER_NAME, level=logging.WARNING) as log_context:
+            with pytest.warns(UserWarning, match="Potential schema drift detected"):
+                predictor.add_input(x=shifted)
+
+        drift_records = [record for record in log_context.records if hasattr(record, "drift_column")]
+        assert drift_records
+        assert all(record.schema_fingerprint.startswith("sha256:") for record in drift_records)
+        assert all(record.drift_reasons for record in drift_records)
+
+    def test_predictor_without_reference_distribution_skips_check(self) -> None:
+        predictor = self._make_predictor()
+        del predictor.schema_distribution
+        shifted = pd.DataFrame({0: np.arange(500, 600), 1: np.arange(600, 700), 2: np.arange(700, 800)})
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            predictor.add_input(x=shifted)

--- a/tests/unit_tests/explainer/test_smart_predictor.py
+++ b/tests/unit_tests/explainer/test_smart_predictor.py
@@ -1386,7 +1386,7 @@ class TestSmartPredictorSchemaDrift(unittest.TestCase):
 
     LOGGER_NAME = "shapash.smartpredictor"
 
-    def _make_predictor(self) -> SmartPredictor:
+    def _make_predictor(self, schema_drift_config=None) -> SmartPredictor:
         dataframe_x = pd.DataFrame(
             {
                 0: np.arange(100),
@@ -1399,13 +1399,27 @@ class TestSmartPredictorSchemaDrift(unittest.TestCase):
         y_pred = pd.DataFrame(clf.predict(dataframe_x), columns=["pred"])
         xpl = SmartExplainer(model=clf, features_dict={})
         xpl.compile(x=dataframe_x, y_pred=y_pred)
-        return xpl.to_smartpredictor()
+        return xpl.to_smartpredictor(schema_drift_config=schema_drift_config)
 
     def test_to_smartpredictor_stores_reference_distribution(self) -> None:
         predictor = self._make_predictor()
 
         assert predictor.schema_distribution
         assert set(predictor.schema_distribution) == {0, 1, 2}
+
+    def test_to_smartpredictor_stores_resolved_drift_config(self) -> None:
+        predictor = self._make_predictor({"numeric_median_iqr_threshold": 10.0})
+
+        assert predictor.schema_drift_config["numeric_median_iqr_threshold"] == 10.0
+        assert predictor.schema_drift_config["missing_rate_delta_threshold"] == 0.1
+
+    def test_add_input_uses_custom_drift_threshold(self) -> None:
+        predictor = self._make_predictor({"numeric_median_iqr_threshold": 100.0})
+        shifted = pd.DataFrame({0: np.arange(500, 600), 1: np.arange(600, 700), 2: np.arange(700, 800)})
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            predictor.add_input(x=shifted)
 
     def test_add_input_stable_data_does_not_warn(self) -> None:
         predictor = self._make_predictor()

--- a/tests/unit_tests/utils/test_drift.py
+++ b/tests/unit_tests/utils/test_drift.py
@@ -1,8 +1,9 @@
 """Unit tests for lightweight SmartPredictor schema-drift utilities."""
 
 import pandas as pd
+import pytest
 
-from shapash.utils.drift import compute_schema_distribution, detect_schema_drift
+from shapash.utils.drift import compute_schema_distribution, detect_schema_drift, resolve_schema_drift_config
 
 
 def test_compute_schema_distribution_numeric_and_categorical() -> None:
@@ -73,3 +74,24 @@ def test_detect_schema_drift_skips_small_batches() -> None:
     current = compute_schema_distribution(pd.DataFrame({"age": range(200, 210)}))
 
     assert detect_schema_drift(reference, current) == {}
+
+
+def test_detect_schema_drift_uses_custom_thresholds() -> None:
+    reference = compute_schema_distribution(pd.DataFrame({"age": range(100)}))
+    current = compute_schema_distribution(pd.DataFrame({"age": range(200, 300)}))
+
+    assert detect_schema_drift(reference, current, {"numeric_median_iqr_threshold": 10.0}) == {}
+
+
+def test_detect_schema_drift_uses_custom_minimum_sample_size() -> None:
+    reference = compute_schema_distribution(pd.DataFrame({"age": range(100)}))
+    current = compute_schema_distribution(pd.DataFrame({"age": range(200, 210)}))
+
+    drift = detect_schema_drift(reference, current, {"min_sample_size": 10})
+
+    assert "age" in drift
+
+
+def test_resolve_schema_drift_config_rejects_unknown_settings() -> None:
+    with pytest.raises(ValueError, match="Unknown schema drift configuration keys"):
+        resolve_schema_drift_config({"unknown_threshold": 1.0})

--- a/tests/unit_tests/utils/test_drift.py
+++ b/tests/unit_tests/utils/test_drift.py
@@ -1,0 +1,75 @@
+"""Unit tests for lightweight SmartPredictor schema-drift utilities."""
+
+import pandas as pd
+
+from shapash.utils.drift import compute_schema_distribution, detect_schema_drift
+
+
+def test_compute_schema_distribution_numeric_and_categorical() -> None:
+    x = pd.DataFrame(
+        {
+            "age": [20.0, 30.0, 40.0, None],
+            "segment": ["a", "a", "b", None],
+        }
+    )
+
+    summary = compute_schema_distribution(x)
+
+    assert summary["age"] == {
+        "kind": "numeric",
+        "sample_size": 4,
+        "missing_rate": 0.25,
+        "min": 20.0,
+        "q25": 25.0,
+        "median": 30.0,
+        "q75": 35.0,
+        "max": 40.0,
+    }
+    assert summary["segment"]["kind"] == "categorical"
+    assert summary["segment"]["missing_rate"] == 0.25
+    assert summary["segment"]["cardinality"] == 2
+
+
+def test_detect_schema_drift_stable_input_is_empty() -> None:
+    x = pd.DataFrame({"age": range(100), "segment": ["a", "b"] * 50})
+    reference = compute_schema_distribution(x)
+
+    assert detect_schema_drift(reference, compute_schema_distribution(x.copy())) == {}
+
+
+def test_detect_schema_drift_numeric_median_shift() -> None:
+    reference = compute_schema_distribution(pd.DataFrame({"age": range(100)}))
+    current = compute_schema_distribution(pd.DataFrame({"age": range(200, 300)}))
+
+    drift = detect_schema_drift(reference, current)
+
+    assert "age" in drift
+    assert any("median shifted" in reason for reason in drift["age"])
+
+
+def test_detect_schema_drift_missing_rate_change() -> None:
+    reference = compute_schema_distribution(pd.DataFrame({"age": range(100)}))
+    current = compute_schema_distribution(pd.DataFrame({"age": [None] * 20 + list(range(80))}))
+
+    drift = detect_schema_drift(reference, current)
+
+    assert "age" in drift
+    assert any("missing rate changed" in reason for reason in drift["age"])
+
+
+def test_detect_schema_drift_categorical_frequency_change() -> None:
+    reference = compute_schema_distribution(pd.DataFrame({"segment": ["a"] * 80 + ["b"] * 20}))
+    current = compute_schema_distribution(pd.DataFrame({"segment": ["a"] * 20 + ["b"] * 80}))
+
+    drift = detect_schema_drift(reference, current)
+
+    assert "segment" in drift
+    assert any("total variation" in reason for reason in drift["segment"])
+
+
+def test_detect_schema_drift_skips_small_batches() -> None:
+    """Avoid noisy drift warnings for individual or very small inference requests."""
+    reference = compute_schema_distribution(pd.DataFrame({"age": range(100)}))
+    current = compute_schema_distribution(pd.DataFrame({"age": range(200, 210)}))
+
+    assert detect_schema_drift(reference, current) == {}


### PR DESCRIPTION
# Description

Completes Gap B from #734 through the dedicated follow-up #755: lightweight, dependency-free schema-drift detection tailored to `SmartPredictor`.

The implementation follows the design agreed with maintainers in #734:

- no `skrub` runtime dependency (its per-column summaries were used as design inspiration only);
- reference summaries live inside the `SmartPredictor` pickle as `schema_distribution`, not in the external manifest sidecar from #722;
- older predictors without this attribute continue to load and skip drift checks;
- drift warns and logs, but does not reject input.

## Implementation

- New `shapash.utils.drift` module computes compact reference summaries:
  - numeric: sample size, missing rate, min/max, median, q25 and q75;
  - categorical: sample size, missing rate, cardinality, top-10 frequencies and an `other` bucket.
- `SmartExplainer.to_smartpredictor()` computes and transfers the reference summaries.
- `SmartPredictor.add_input()` compares structurally valid incoming batches against the reference before preprocessing.
- Material drift emits one actionable `UserWarning` per column and a `WARNING` record on `shapash.smartpredictor` with `schema_fingerprint`, `drift_column`, and `drift_reasons` extras.
- Inputs are never rejected for drift.
- Drift checks require at least 30 reference and current rows, avoiding noisy alerts for individual inference requests or tiny batches.

## Initial thresholds

- Missing-rate absolute change: `>= 0.10`.
- Numeric median shift: `>= 1.5` reference IQRs.
- Categorical total-variation distance: `>= 0.20`.
- Categorical cardinality ratio: `>= 1.5`.

These are private module constants for the initial implementation; a configurable public policy can be considered later based on operational feedback.

Fixes #755.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update required

# How Has This Been Tested?

Added five utility tests and four SmartPredictor integration tests covering:

- numeric and categorical summary generation;
- stable input producing no drift;
- numeric median drift;
- missing-rate drift;
- categorical frequency drift;
- small-batch suppression;
- reference summaries transferred by `to_smartpredictor()`;
- warnings plus structured logging with schema fingerprint;
- backward compatibility when `schema_distribution` is absent.

```bash
python -m pytest \
  tests/unit_tests/utils/test_drift.py \
  tests/unit_tests/explainer/test_smart_predictor.py \
  tests/unit_tests/utils/test_load_smartpredictor.py -q
# 61 passed

ruff check \
  shapash/utils/drift.py \
  shapash/explainer/smart_predictor.py \
  shapash/explainer/smart_explainer.py
# All checks passed!
```

**Test configuration**

- macOS
- Python 3.12.13
- Current `MAIF/shapash:master`

# Checklist

- [x] Code follows project style guidelines.
- [x] New code has type hints.
- [x] Self-review completed.
- [x] No new runtime dependency added.
- [x] Tests prove the feature works and remains backward compatible.
- [x] Existing focused SmartPredictor tests pass.
- [x] New production code passes Ruff.

## Notes

- The minimum-batch guard is intentional: SmartPredictor is also used for single-row inference, where distribution statistics are not meaningful.
- Categorical total variation compares the reference top-K buckets plus one `other` bucket, avoiding double counting when current and reference top-K sets differ.
- Strict rejection is deliberately out of scope for this first version.
