### PR TITLE
Honour force in compute_features_import

### DIFF
--- a/shapash/explainer/smart_explainer.py
+++ b/shapash/explainer/smart_explainer.py
@@ -1254,7 +1254,7 @@ class SmartExplainer:
             contributions=self.contributions, explain_data=self.explain_data, subset=None, norm=1
         )
 
-        if self.features_groups is not None and self.features_imp_groups is None:
+        if self.features_groups is not None and (force or self.features_imp_groups is None):
             self.features_imp_groups = self.state.compute_features_import(self.contributions_groups, norm=1)
 
         if local:

--- a/tests/unit_tests/explainer/test_smart_explainer.py
+++ b/tests/unit_tests/explainer/test_smart_explainer.py
@@ -996,6 +996,47 @@ class TestSmartExplainer(unittest.TestCase):
         assert expect1.round(8).equals(xpl.features_imp[0].round(8))
         assert expect2.round(8).equals(xpl.features_imp[1].round(8))
 
+    def test_compute_features_import_force_recomputes_groups(self):
+        """
+        Unit test compute_features_import with force=True
+
+        The grouped importances are cached, and `force` is documented to
+        recompute even when the value already exists.
+        """
+        contributions = pd.DataFrame(
+            [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+            columns=["contribution_0", "contribution_1", "contribution_2", "contribution_3"],
+            index=[0, 1, 2],
+        )
+
+        def build():
+            xpl = SmartExplainer(self.model)
+            xpl.features_imp = None
+            xpl.contributions = contributions
+            xpl.contributions_groups = contributions
+            xpl.features_groups = {"group_0": ["contribution_0", "contribution_1"]}
+            xpl.backend = ShapBackend(model=DecisionTreeClassifier().fit([[0]], [[0]]))
+            xpl.backend.state = SmartState()
+            xpl.state = SmartState()
+            xpl.explain_data = None
+            xpl._case = "regression"
+            return xpl
+
+        expected = contributions.abs().sum().sort_values(ascending=True)
+        expected = expected / expected.sum()
+
+        # force=True must refresh an already-populated cache
+        xpl = build()
+        xpl.features_imp_groups = "stale"
+        xpl.compute_features_import(force=True)
+        assert expected.equals(xpl.features_imp_groups)
+
+        # force=False leaves an existing value alone, as before
+        xpl = build()
+        xpl.features_imp_groups = "stale"
+        xpl.compute_features_import()
+        assert xpl.features_imp_groups == "stale"
+
     def test_to_smartpredictor_1(self):
         """
         Unit test 1  to_smartpredictor


### PR DESCRIPTION
# Description

`SmartExplainer.compute_features_import` accepts and documents a `force` flag:

> `force : bool, optional` — If `True`, recomputes feature importance even if it has already been calculated. Default is `False`.

but never reads it. The grouped importances are the only cached value in the method, and they are guarded by a bare `None` check, so once `features_imp_groups` is populated no call can refresh it:

```python
if self.features_groups is not None and self.features_imp_groups is None:
```

This looks like a refactor casualty rather than an unfinished feature — the method used to read the flag (`if self.features_imp is None or force:`) until that line was dropped in ca6c30d ("improved backend api"), leaving the parameter and its docstring behind.

The change makes the group cache honour the flag:

```python
if self.features_groups is not None and (force or self.features_imp_groups is None):
```

The `force=False` path is untouched, and the ungrouped `features_imp` keeps being recomputed unconditionally exactly as it is today, so nothing changes for existing callers who do not pass `force`.

Fixes #761

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] **New unit test** — `test_compute_features_import_force_recomputes_groups` in `tests/unit_tests/explainer/test_smart_explainer.py`: asserts that `force=True` refreshes an already-populated `features_imp_groups`, and that `force=False` still leaves it alone. It fails on `master` (`assert False`) and passes with this change.
- [x] **Existing suite** — `tests/unit_tests/explainer/test_smart_explainer.py`: 54 passed. Two tests (`test_compile_4`, `test_generate_report`) fail in my environment, but they fail identically on an unmodified checkout, so they are unrelated to this change.
- [x] **Manual reproduction** — the snippet in #761 prints `STALE` before the change and the recomputed importances after it.

**Test Configuration**:
* OS: Windows 11
* Python version: 3.13
* Shapash version: 2.9.0 (from `master`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — not needed; the existing docstring already describes the intended behaviour, this makes the code match it
- [x] My changes generate no new warnings

`ruff check` reports the same set of findings as on an unmodified checkout, apart from two additional `S101` ("use of `assert`") in the new test — the module already contains 93 of those, so the new test follows the existing convention.
