### PR TITLE
Fix docstrings that name parameters the functions do not have

### DIFF
--- a/shapash/explainer/smart_state.py
+++ b/shapash/explainer/smart_state.py
@@ -154,7 +154,7 @@ class SmartState:
         var_dict: pd.DataFrame
             Dataframe with features indexes ordered
             by contribution.
-        feature_list: list
+        features_list: list
             List of index, feature to hide.
 
         Returns
@@ -248,7 +248,7 @@ class SmartState:
         ----------
         s_contrib: pd.DataFrame
             Matrix with both positive and negative values
-        mask: pd.DataFrame
+        masks: pd.DataFrame
             Matrix with only True or False elements. False elements are the hidden elements.
 
         Returns

--- a/shapash/manipulation/filters.py
+++ b/shapash/manipulation/filters.py
@@ -17,7 +17,7 @@ def hide_contributions(var_dict, features_list):
     var_dict: pd.DataFrame
         Dataframe with features indexes ordered
         by contribution.
-    feature_list: list
+    features_list: list
         List of index, feature to hide.
 
     Returns
@@ -35,7 +35,7 @@ def cap_contributions(s_contrib, threshold=0.1):
 
     Parameters
     ----------
-    s : pandas.DataFrame
+    s_contrib : pandas.DataFrame
         Local contributions, positive and negative values.
     threshold: float, optional (default: 0.1)
         User defined threshold above which local contributions are hidden.
@@ -53,11 +53,11 @@ def sign_contributions(dataframe, positive=True):
     """
     Returns Boolean values depending on
     the signs of local contributions
-    stored in df and on the positive parameter.
+    stored in dataframe and on the positive parameter.
 
     Parameters
     ----------
-    df : pandas.DataFrame
+    dataframe : pandas.DataFrame
         Local contributions of the model.
     positive : boolean (default=True)
         True to evaluate positive value.
@@ -82,7 +82,7 @@ def cutoff_contributions_old(dataframe, max_contrib):
 
     Parameters
     ----------
-    df : pd.Dataframe
+    dataframe : pd.Dataframe
         DataFrame is a sorted local contributions matrix.
     max_contrib: int
         The k most important contributions to keep.

--- a/shapash/manipulation/select_lines.py
+++ b/shapash/manipulation/select_lines.py
@@ -12,7 +12,7 @@ def select_lines(dataframe, condition=None):
     on a boolean condition.
     Parameters
     ----------
-    df : pandas.DataFrame
+    dataframe : pandas.DataFrame
         Input dataframe used for the query.
     condition : string
         A boolean condition expressed as string.
@@ -33,7 +33,7 @@ def keep_right_contributions(y_pred, contributions, _case, _classes, label_dict,
 
     Parameters
     ----------
-    ypred: pandas.DataFrame (optional)
+    y_pred: pandas.DataFrame (optional)
             User-specified prediction values.
     contributions: pandas.DataFrame (regression) or list (classification) (optional)
         local contributions aggregated if the preprocessing part requires it (e.g. one-hot encoding)

--- a/shapash/plots/plot_feature_importance.py
+++ b/shapash/plots/plot_feature_importance.py
@@ -215,7 +215,7 @@ def _plot_features_import(
         the different styles used in the different outputs of Shapash
     inv_features_dict: dict
         Inverse features_dict mapping.
-    features_groups : dict, optional (default: None)
+    features_groups_keys : dict, optional (default: None)
         Keys of the dictionnary containing features that should be grouped together.
     feature_imp2 : pd.Series, optional (default: None)
         The contributions associate
@@ -347,7 +347,7 @@ def _plot_local_features_import(
         Inverse features_dict mapping.
     title : str
         Title of the plot, default set to 'Features Importance'
-    features_groups : dict, optional (default: None)
+    features_groups_keys : dict, optional (default: None)
         Keys of the dictionnary containing features that should be grouped together.
     addnote : String (default: None)
         Specify a note to display

--- a/shapash/webapp/utils/callbacks.py
+++ b/shapash/webapp/utils/callbacks.py
@@ -180,9 +180,9 @@ def select_data_from_date_filters(
 
     Parameters
     ----------
-    round_dataframe : pd.DataFrame
+    df : pd.DataFrame
         Data to sample
-    id_feature : list
+    feature_id : list
         features ids
     id_date : list
         date features ids


### PR DESCRIPTION
Twelve Parameters entries name an argument the function doesn't accept, so following the docstring and passing that keyword raises `TypeError`. Docs only — no code touched, no behaviour change.

| file | function | documented | actual |
|---|---|---|---|
| `manipulation/filters.py` | `hide_contributions` | `feature_list` | `features_list` |
| | `cap_contributions` | `s` | `s_contrib` |
| | `sign_contributions` | `df` | `dataframe` |
| | `cutoff_contributions_old` | `df` | `dataframe` |
| `manipulation/select_lines.py` | `select_lines` | `df` | `dataframe` |
| | `keep_right_contributions` | `ypred` | `y_pred` |
| `explainer/smart_state.py` | `hide_contributions` | `feature_list` | `features_list` |
| | `compute_masked_contributions` | `mask` | `masks` |
| `plots/plot_feature_importance.py` | `_plot_features_import` | `features_groups` | `features_groups_keys` |
| | `_plot_local_features_import` | `features_groups` | `features_groups_keys` |
| `webapp/utils/callbacks.py` | `select_data_from_date_filters` | `round_dataframe` | `df` |
| | | `id_feature` | `feature_id` |

What makes these look like slips rather than a house convention is that shapash already documents the same arguments correctly in neighbouring code:

- `SmartState.cap_contributions` documents `s_contrib`, while the `filters.py` function it delegates to documents the same argument as `s`.
- `MultiDecorator.compute_masked_contributions` documents `masks`, while `SmartState.compute_masked_contributions` — same signature — documents `mask`.
- In `plot_feature_importance.py`, the first function to take `features_groups_keys` documents it under that name; the two later ones call it `features_groups`.

I also updated one prose reference, in `sign_contributions`: "the signs of local contributions stored in df" now says `dataframe`, since `df` there is naming the argument. I left alone wording where the word reads as domain vocabulary rather than an argument name — e.g. `keep_right_contributions`' summary line "Keep the right contributions/summary for the right ypred".

Checked with the repo's own tooling: `ruff check` → `All checks passed!` and `ruff format --check` → `5 files already formatted`, both identical before and after the change. (`black --check` does complain, but it does so on the unmodified files too — black defaults to 88 columns while this project sets `line-length = 120` for ruff.)
