### PR TITLE
test(check): remove shadowed duplicate test_check_preprocessing_options_1

### DIFF
--- a/tests/unit_tests/utils/test_check.py
+++ b/tests/unit_tests/utils/test_check.py
@@ -373,26 +373,6 @@ class TestCheck(unittest.TestCase):
                 features_dict, model, columns_dict, features_types, mask_params, preprocessing
             )
 
-    def test_check_preprocessing_options_1(self):
-        """
-        Unit test 1 for check_preprocessing_options
-        """
-        y = pd.DataFrame(data=[0, 1], columns=["y"])
-        train = pd.DataFrame({"num1": [0, 1], "num2": [0, 2], "other": ["A", "B"]})
-        enc = ColumnTransformer(
-            transformers=[("power", skp.QuantileTransformer(n_quantiles=2), ["num1", "num2"])], remainder="drop"
-        )
-        enc.fit(train, y)
-
-        with self.assertRaises(ValueError):
-            check_preprocessing_options(enc)
-
-        enc = ColumnTransformer(
-            transformers=[("power", skp.QuantileTransformer(n_quantiles=2), ["num1", "num2"])], remainder="passthrough"
-        )
-        enc.fit(train, y)
-        check_preprocessing_options(enc)
-
     def test_check_consistency_model_features_4(self):
         """
         Test check_consistency_model_features 1


### PR DESCRIPTION
### Problem

In `tests/unit_tests/utils/test_check.py`, the `TestCheck` class defines `test_check_preprocessing_options_1` **twice** (around line 376 and line 587). Because Python binds the later definition, the second one shadows the first, so the earlier copy is silently **never collected or run**.

The two bodies are not equivalent:

- The **live** copy (later definition) exercises the current signature:
  ```python
  check_preprocessing_options(columns_dict, features_dict, encoder_fitted, [encoder_fitted])
  ```
  and asserts both the `remainder="drop"` result dict and the `remainder="passthrough"` (`None`) case.

- The **shadowed** copy (earlier definition) still calls the obsolete single-argument form:
  ```python
  with self.assertRaises(ValueError):
      check_preprocessing_options(enc)
  ```
  which no longer matches `check_preprocessing_options(columns_dict, features_dict, preprocessing=None, list_preprocessing=None)`. If it were ever un-shadowed it would raise `TypeError` (missing `features_dict`) instead of testing anything meaningful.

### Fix

Remove the dead, shadowed duplicate. Its drop/passthrough coverage is already provided by the live definition, so this changes nothing at runtime — it only deletes an obsolete test that never ran and clears up the duplicate name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
