### PR TITLE
Fix documented defaults that disagree with the signatures

### DIFF
--- a/shapash/explainer/smart_plotter.py
+++ b/shapash/explainer/smart_plotter.py
@@ -233,7 +233,7 @@ class SmartPlotter:
         label: integer or string (default None)
             If the label is of string type, check if it can be changed to integer to select the
             good dataframe object.
-        show_masked: bool (default: False)
+        show_masked: bool (default: True)
             show the sum of the contributions of the hidden variable
         show_predict: bool (default: True)
             show predict or predict proba value
@@ -699,7 +699,7 @@ class SmartPlotter:
         normalize_by_nb_samples : bool, optional, default: False
             Normalizes feature importance by the number of samples.
             This is only applicable when `mode` is set to 'cumulative'.
-        degree : int, optional, default: 0
+        degree : str or float, optional, default: 'slider'
             Degree of adjustment to apply to the cumulative feature contributions curve.
             This is only applicable when `mode` is set to 'cumulative'.
 
@@ -1109,7 +1109,7 @@ class SmartPlotter:
         violin_maxf: int (optional, default: 10)
             maximum number modality to plot violin. If the feature specified with col argument
             has more modalities than violin_maxf, a scatter plot will be choose
-        max_points: int (optional, default: 2000)
+        max_points: int (optional, default: 500)
             maximum number of points to plot in contribution plot. if input dataset is bigger than
             max_points, a sample limits the number of points to plot.
             nb: you can also limit the number using 'selection' parameter.
@@ -1403,7 +1403,7 @@ class SmartPlotter:
         optimized : boolean, optional
             True if we want to potentially accelerate the computation of the correlation matrix by reducing the
             lenght of the data and the number of modalties per columns.
-        max_features : int (default: 10)
+        max_features : int (default: 20)
             Max number of features to show on the matrix.
         features_to_hide : list (optional)
             List of features that will not appear on the graph
@@ -1414,7 +1414,7 @@ class SmartPlotter:
             Correlation method used. 'phik' or 'pearson' are possible values. 'phik' is used by default.
         width : Int (default: 900)
             Plotly figure - layout width
-        height : Int (default: 600)
+        height : Int (default: 500)
             Plotly figure - layout height
         degree  : int, optional, (default 2.5)
             degree applied on the correlation matrix in order to focus more or less the clustering
@@ -1905,9 +1905,9 @@ class SmartPlotter:
             Estimated targets as returned by a classifier.
         colors_dict : dict
             dict of colors used
-        width : int, optional, default=7
+        width : int, optional, default=700
             The width of the generated figure, in inches.
-        height : int, optional, default=4
+        height : int, optional, default=500
             The height of the generated figure, in inches.
         color_quantile_cap : float, optional, default=None
             Upper quantile used to cap the cell color, useful on
@@ -2143,7 +2143,7 @@ class SmartPlotter:
         label : int or str, optional, default=-1
             Label to use in classification tasks (e.g., class index or name). Ignored in regression.
 
-        threshold_top_features : float, optional, default=0.9
+        threshold_top_features : float, optional, default=0.95
             Feature selection threshold based on mean absolute contribution values. Only features contributing
             to the cumulative threshold are retained for projection.
 

--- a/shapash/plots/plot_correlations.py
+++ b/shapash/plots/plot_correlations.py
@@ -46,7 +46,7 @@ def plot_correlations(
     optimized : boolean, optional
         True if we want to potentially accelerate the computation of the correlation matrix by reducing the
         lenght of the data and the number of modalties per columns.
-    max_features : int (default: 10)
+    max_features : int (default: 20)
         Max number of features to show on the matrix.
     features_to_hide : list (optional)
         List of features that will not appear on the graph
@@ -57,7 +57,7 @@ def plot_correlations(
         Correlation method used. 'phik' or 'pearson' are possible values. 'phik' is used by default.
     width : Int (default: 900)
         Plotly figure - layout width
-    height : Int (default: 600)
+    height : Int (default: 500)
         Plotly figure - layout height
     degree  : int, optional, (default 2.5)
         degree applied on the correlation matrix in order to focus more or less the clustering

--- a/shapash/plots/plot_evaluation_metrics.py
+++ b/shapash/plots/plot_evaluation_metrics.py
@@ -946,7 +946,7 @@ def plot_clustering_by_explainability(
     projections : np.ndarray or None, optional, default=None
         Precomputed 2D TSNE projections. If None, projections will be computed within the function.
     labels
-    keep_quantile : tuple of float, optional, default=(0.05, 0.95)
+    keep_quantile : tuple of float, optional, default=None
         Quantiles to retain for color scaling, helping to manage outliers.
     random_state : int, optional, default=79
         Random seed for reproducibility of the TSNE projection.


### PR DESCRIPTION
Eleven Parameters entries state a default the function doesn't have. Docs only, no behaviour change.

| file | function | parameter | documented | actual |
|---|---|---|---|---|
| `explainer/smart_plotter.py` | `local_plot` | `show_masked` | `False` | `True` |
| | `features_importance` | `degree` | `int, default: 0` | `'slider'` |
| | `interactions_plot` | `max_points` | `2000` | `500` |
| | `correlations_plot` | `max_features` | `10` | `20` |
| | `correlations_plot` | `height` | `600` | `500` |
| | `confusion_matrix_plot` | `width` | `7` | `700` |
| | `confusion_matrix_plot` | `height` | `4` | `500` |
| | `clustering_by_explainability_plot` | `threshold_top_features` | `0.9` | `0.95` |
| `plots/plot_correlations.py` | `plot_correlations` | `max_features` | `10` | `20` |
| | `plot_correlations` | `height` | `600` | `500` |
| `plots/plot_evaluation_metrics.py` | `plot_clustering_by_explainability` | `keep_quantile` | `(0.05, 0.95)` | `None` |

Two of them are worth a note:

**`features_importance.degree`** was wrong in type as well as value — documented as `int, optional, default: 0`, but the signature is `degree="slider"`. `plot_feature_importance.py`, which this delegates to, already documents the same argument correctly as `degree : str or float, optional` with `degree="slider"`, so I matched that.

**`plot_clustering_by_explainability.keep_quantile`** is documented as `default=(0.05, 0.95)` but the signature is `None`. I checked whether `None` gets turned into that tuple downstream and it doesn't — `tuning_colorscale`, which receives it, also defaults `keep_quantile=None`. (The separate `clustering_by_explainability_plot` in `smart_plotter.py` genuinely does default to `(0.05, 0.95)` and is documented correctly; I left that one alone.)

`confusion_matrix_plot`'s `width`/`height` documented as `7`/`4` against `700`/`500` look like inch-based figure sizes carried over from a matplotlib-style signature — these are plotly pixel dimensions.

I verified each entry by comparing the parsed signature default against the raw docstring line rather than by eye, and only changed the ones that actually disagree. Checked with the repo's own tooling: `ruff check` → `All checks passed!`, `ruff format --check` → `3 files already formatted`.
